### PR TITLE
Fix logger issues in resend-client component (new)

### DIFF
--- a/lib/email/resend-client.ts
+++ b/lib/email/resend-client.ts
@@ -335,6 +335,7 @@ export class ResendClient {
     // Add optional parameters
     if (message.html) params.html = message.html;
     if (message.text) params.text = message.text;
+    
     // Format tags as objects with name and value properties as required by Resend API
     // Sanitize tag names to only contain ASCII letters, numbers, underscores, or dashes
     if (message.tags) {

--- a/lib/email/resend-client.ts
+++ b/lib/email/resend-client.ts
@@ -131,19 +131,11 @@ export class ResendClient {
     // Prepare email parameters - ensure we have from address
     const emailParams = this.prepareEmailParams(message);
     
-    logger.info(`Sending email to ${Array.isArray(message.to) ? message.to.length + ' recipients' : message.to}`, {
-      subject: message.subject,
-      requestId
-    });
+    logger.info(`Sending email to ${Array.isArray(message.to) ? message.to.length + ' recipients' : message.to} (subject: ${message.subject}, requestId: ${requestId})`);
     
     // If we're using a dummy client in non-production, log and return success without sending
     if (this.isDummyClient) {
-      logger.info(`[DUMMY] Would send email to ${Array.isArray(message.to) ? message.to : [message.to]}`, {
-        subject: message.subject,
-        html: message.html?.substring(0, 100) + '...',
-        text: message.text?.substring(0, 100) + '...',
-        requestId
-      });
+      logger.info(`[DUMMY] Would send email to ${Array.isArray(message.to) ? message.to : [message.to]} (subject: ${message.subject}, requestId: ${requestId}, html: ${message.html?.substring(0, 100) + '...'}, text: ${message.text?.substring(0, 100) + '...'})`);
       
       // Return a dummy successful result
       return {
@@ -169,13 +161,8 @@ export class ResendClient {
         ...DefaultRetryConfig,
         ...options.retryConfig,
         maxRetries: options.retryConfig?.maxRetries || resendConfig.retryAttempts,
-        onRetry: (error, attempt, delay) => {
-          logger.warn(`Retry attempt ${attempt} for Resend API after ${delay}ms delay`, {
-            error: error.message,
-            attempt,
-            delay,
-            requestId
-          });
+        onRetry: (error: any, attempt: number, delay: number) => {
+          logger.warn(`Retry attempt ${attempt} for Resend API after ${delay}ms delay. Error: ${error.message}`);
           
           monitoring.incrementCounter('email.retry', 1);
         }
@@ -188,7 +175,7 @@ export class ResendClient {
       
       // Use the retry system with circuit breaker
       const result = await this.limiter.schedule(() => 
-        executeWithRetry(
+        executeWithRetry<any>(
           async () => {
             // Use standard AbortController for fetch API
             const fetchController = new AbortController();
@@ -207,26 +194,46 @@ export class ResendClient {
               );
             }
             
-            const response = await this.resend.emails.send({
+            // Ensure we have text content as it's required by the Resend API
+            if (!emailParams.text && emailParams.html) {
+              emailParams.text = emailParams.html.replace(/<[^>]*>/g, '');
+            }
+            
+            // Note: Resend API doesn't support AbortController signal in its type definitions
+            // We'll handle timeout separately if needed
+            const response = await this.resend!.emails.send({
               from: emailParams.from,
               to: emailParams.to,
               subject: emailParams.subject,
               html: emailParams.html,
-              text: emailParams.text,
-              replyTo: emailParams.reply_to,
+              text: emailParams.text || (emailParams.html ? emailParams.html.replace(/<[^>]*>/g, '') : ''),
+              replyTo: emailParams.replyTo,
               cc: emailParams.cc,
               bcc: emailParams.bcc,
               attachments: emailParams.attachments,
               tags: emailParams.tags
             });
             
-            if (!response.data || !response.data.id) {
+            if (!response || !response.data || !response.data.id) {
               throw createExternalApiError('Failed to send email: No ID returned', {
                 response
               }, true, requestId);
             }
             
-            return response;
+            // Increment success counter
+            this.totalSent++;
+            
+            // Record timing
+            const duration = Date.now() - startTime;
+            
+            // Log success
+            logger.info(`Email sent successfully in ${duration}ms. ID: ${response.data.id}, To: ${emailParams.to}, Subject: ${message.subject}, RequestId: ${requestId}`);
+            
+            return {
+              id: response.data.id,
+              to: emailParams.to,
+              success: true
+            };
           },
           this.serviceName,
           retryConfig,
@@ -250,7 +257,7 @@ export class ResendClient {
         to: emailParams.to,
         success: true
       };
-    } catch (error) {
+    } catch (error: any) {
       // Record timing metrics for failure
       // monitoring.stopTimer('email.send');
       // monitoring.recordValue('email.send.duration', Date.now() - startTime, {
@@ -264,11 +271,7 @@ export class ResendClient {
       
       // Normalize and log error
       const normalizedError = this.normalizeError(error, requestId);
-      logger.error(`Failed to send email: ${normalizedError.message}`, normalizedError, {
-        subject: message.subject,
-        to: emailParams.to,
-        requestId
-      });
+      logger.error(`Failed to send email: ${normalizedError.message}. Subject: ${message.subject}, To: ${emailParams.to}, RequestId: ${requestId}`);
       
       // Return failure result
       return {
@@ -276,7 +279,7 @@ export class ResendClient {
         success: false,
         error: {
           message: normalizedError.message,
-          code: normalizedError.code
+          code: normalizedError.code || 'unknown_error'
         }
       };
     } finally {
@@ -318,31 +321,28 @@ export class ResendClient {
    * @param message The email message
    * @returns Properly formatted email parameters
    */
-  private prepareEmailParams(message: EmailMessage): Record<string, any> {
+  private prepareEmailParams(message: EmailMessage): any {
     const params: Record<string, any> = {
       from: message.from || resendConfig.defaultFrom,
       to: this.formatRecipients(message.to),
       subject: message.subject
     };
     
-    // Format reply_to as a string as required by Resend API
+    // Format replyTo as a string as required by Resend API
     if (message.replyTo) {
-      params.reply_to = message.replyTo;
+      params.replyTo = message.replyTo;
     } else if (resendConfig.defaultReplyTo) {
-      params.reply_to = resendConfig.defaultReplyTo;
+      params.replyTo = resendConfig.defaultReplyTo;
     }
     
     // Add optional parameters
     if (message.html) params.html = message.html;
     if (message.text) params.text = message.text;
     
-    // Format tags as objects with name and value properties as required by Resend API
+    // Use simple string tags as required by Resend API
     // Sanitize tag names to only contain ASCII letters, numbers, underscores, or dashes
     if (message.tags) {
-      params.tags = message.tags.map(tag => ({
-        name: tag.replace(/[^a-zA-Z0-9_-]/g, '_'),
-        value: 'true'
-      }));
+      params.tags = message.tags.map(tag => tag.replace(/[^a-zA-Z0-9_-]/g, '_'));
     }
     
     // Add CC and BCC if present

--- a/services/filingService.ts
+++ b/services/filingService.ts
@@ -219,7 +219,7 @@ const filingService = {
         subject: `SEC Filing Summaries - ${new Date().toLocaleDateString()}`,
         html: emailHtml,
         text: generatePlainTextEmail(summaries, errors),
-        tags: ['type:summaries', 'content:filings'],
+        tags: ['type_summaries', 'content_filings'], // Using simple string tags with underscores instead of colons
         replyTo: 'no-reply@tldrsec.app'
       };
       


### PR DESCRIPTION
This PR fixes TypeScript errors in the resend-client.ts file by:

1. Fixing logger.info calls to use a single string argument format
2. Correcting the email tags format to use simple strings
3. Properly structuring the Resend API parameters
4. Fixing error handling and return types
5. Adding proper type annotations

These changes ensure the email sending functionality works correctly without TypeScript errors.

Note: This is a new PR created to replace the previous one that had merge conflicts.