### PR TITLE
Fix: Add Form 4 schema to schemaMap to resolve JSON parsing errors

### DIFF
--- a/lib/ai/parsers/schema-validators.ts
+++ b/lib/ai/parsers/schema-validators.ts
@@ -175,6 +175,8 @@ const schemaMap: Record<SECFilingType, z.ZodTypeAny> = {
   'S-4': schemaS1,   // Similar to S-1 but for business combinations
   '424B': schemaGeneric,
   'DEF 14A': schemaDEF14A,
+  '4': schemaForm4,  // Form 4 for insider trading reports
+  '144': schemaGeneric, // Form 144 for planned sales of securities
   'Generic': schemaGeneric
 };
 

--- a/lib/ai/prompts/prompt-types.ts
+++ b/lib/ai/prompts/prompt-types.ts
@@ -15,6 +15,8 @@ export type SECFilingType =
   | 'S-4'   // Registration for business combinations
   | '424B'  // Prospectus
   | 'DEF 14A' // Proxy statement
+  | '4'     // Form 4 insider trading reports
+  | '144'   // Form 144 planned sales of securities
   | 'Generic'; // Generic prompt for any other filing type
 
 /**
@@ -91,14 +93,6 @@ export interface FilingPromptTemplate {
   contextConfig: ContextWindowConfig;
 }
 
-/**
- * Type definitions for SEC filing prompts
- */
-
-/**
- * SEC filing types supported by the system
- */
-export type SECFilingType = '10-K' | '10-Q' | '8-K' | 'Form4' | 'generic';
 
 /**
  * Schema structure for 10-K (Annual Report) filings


### PR DESCRIPTION
## Problem\nThe Claude summarizer was failing to parse valid JSON from its API response for filings of type 4 (e.g., form 4 filings) for multiple tickers (TSLA, VRT, COIN, NVDA) with the error message "Missing minimum required fields".\n\n## Root Cause\nForm 4 filings had a specific schema defined (), but it wasn't properly mapped in the  object. When processing Form 4 filings, the system was falling back to the generic schema, which led to validation failures.\n\n## Solution\n1. Added Form 4 schema to the schemaMap\n2. Updated SECFilingType to include Form 4 and Form 144 filing types\n3. Removed duplicate SECFilingType definition\n\nThis fix ensures that when the system processes Form 4 filings, it will use the appropriate schema for validation, which matches the structure that Claude is instructed to generate.