### PR TITLE
🔧 fix: resolve duplicate export causing Vercel build failure

### DIFF
--- a/lib/db/transaction-manager.ts
+++ b/lib/db/transaction-manager.ts
@@ -511,5 +511,4 @@ export const transactionUtils = {
   }
 };
 
-// Export the main transaction manager for direct use
-export { TransactionManager, FilingTransactionManager };
+// Classes are already exported above with their declarations


### PR DESCRIPTION
## Summary
- Fixed duplicate export of `TransactionManager` and `FilingTransactionManager` classes
- Resolved webpack parsing error preventing Vercel deployments
- Classes are already exported at their declarations, removed redundant export statement

## Problem
Vercel builds were failing with webpack parsing error:
```
Module parse failed: Duplicate export 'TransactionManager' (387:9)
```

## Solution
Removed the duplicate export statement at the end of `lib/db/transaction-manager.ts` since the classes are already exported with their class declarations.

## Test plan
- [x] Local build completes successfully (`npm run build`)
- [x] No webpack parsing errors
- [x] All existing functionality preserved

🤖 Generated with [Claude Code](https://claude.ai/code)