### PR TITLE
📝 Fix Railway cron localhost connection issue

### DIFF
--- a/RAILWAY_CRON_SETUP.md
+++ b/RAILWAY_CRON_SETUP.md
@@ -45,12 +45,15 @@ Ensure these environment variables are set in Railway:
 
 ### Required Variables
 ```bash
+PUBLIC_URL=https://your-app-name.railway.app
 CRON_SECRET=your-secure-secret-key
 DATABASE_URL=postgresql://...
 ANTHROPIC_API_KEY=sk-ant-api03-...
 RESEND_API_KEY=re_...
 RAILWAY_ENVIRONMENT=production
 ```
+
+⚠️ **CRITICAL**: The `PUBLIC_URL` environment variable must be set to your Railway domain. Railway native cron jobs don't automatically have access to `RAILWAY_PUBLIC_DOMAIN`, causing the cron to fall back to `localhost` which fails.
 
 Check via CLI:
 ```bash
@@ -120,14 +123,22 @@ LIMIT 10;
 
 ### Common Issues
 
-#### 1. Unauthorized Cron Request
+#### 1. Connection to localhost Error
+**Symptom**: `Unable to connect. Is the computer able to access the url?` with `"baseUrl": "http://localhost:8080"`
+
+**Solution**: 
+- Set the `PUBLIC_URL` environment variable in Railway to your deployed domain
+- Example: `PUBLIC_URL=https://your-app-name.railway.app`
+- Railway native cron jobs run separately and don't automatically have `RAILWAY_PUBLIC_DOMAIN`
+
+#### 2. Unauthorized Cron Request
 **Symptom**: `401 Unauthorized` or `Unauthorized cron request` in logs
 
 **Solution**: 
 - Verify `CRON_SECRET` is set correctly
 - Make sure the secret matches in your test calls
 
-#### 2. Database Schema Errors
+#### 3. Database Schema Errors
 **Symptom**: `Unknown argument 'attempts'` or similar Prisma errors
 
 **Solution**:
@@ -135,7 +146,7 @@ LIMIT 10;
 - Fixed in latest deployment
 - Run `railway run npx prisma db push` if needed
 
-#### 3. Cron Jobs Not Triggering
+#### 4. Cron Jobs Not Triggering
 **Symptom**: No cron execution logs
 
 **Solution**:
@@ -143,7 +154,7 @@ LIMIT 10;
 - Verify Railway cron schedule is saved correctly
 - Ensure minimum 5-minute interval (Railway limitation)
 
-#### 4. API Endpoint Errors
+#### 5. API Endpoint Errors
 **Symptom**: 500 errors when testing endpoints
 
 **Solution**:


### PR DESCRIPTION
## Summary
• **Fix critical Railway cron connection error** - Document PUBLIC_URL requirement for cron jobs
• **Add localhost connection troubleshooting** - Explain why Railway native crons fail with localhost  
• **Update environment variable setup** - Include PUBLIC_URL in required variables list
• **Enhanced documentation clarity** - Better organization of common issues and solutions

## Problem Solved
Railway native cron jobs were failing with "Unable to connect. Is the computer able to access the url?" error because they don't automatically have access to `RAILWAY_PUBLIC_DOMAIN` environment variable, causing fallback to `localhost` which fails in the Railway environment.

## Technical Changes
• **Environment Variables**: Added `PUBLIC_URL` as required variable for Railway deployment
• **Troubleshooting Section**: Added specific section for localhost connection errors
• **Documentation Structure**: Reorganized common issues with numbered sections
• **Critical Warnings**: Added prominent warning about PUBLIC_URL requirement

## Test Plan
- [ ] **Documentation Review**: Verify all sections are clear and accurate
- [ ] **Environment Setup**: Test PUBLIC_URL configuration in Railway console
- [ ] **Cron Functionality**: Validate cron jobs work with PUBLIC_URL set correctly
- [ ] **Error Scenarios**: Confirm troubleshooting steps resolve common issues

## Impact
• **Reduced Support Issues**: Clear documentation prevents common setup errors
• **Improved Onboarding**: Developers can set up Railway cron jobs successfully  
• **Better Debugging**: Comprehensive troubleshooting section for common problems
• **System Reliability**: Proper environment configuration ensures cron jobs function correctly

🤖 Generated with [Claude Code](https://claude.ai/code)