### PR TITLE
Fix critical job queue database client bug blocking 394+ pending jobs

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,22 +2,34 @@
 
 **Date**: 2026-01-10
 **Branch**: main
-**Status**: Pipeline Successfully Redeployed - Backlog Processing Restored
+**Status**: Critical Job Queue Bug Fixed - Prisma Client Resolution
 
 ---
 
-## Current Session: Pipeline Redeployment & Backlog Recovery (2026-01-10)
+## Current Session: Critical Job Queue Database Bug Fix (2026-01-10)
 
-Successfully resolved critical pipeline stall affecting 400+ pending jobs. Both Vercel and Cloudflare Worker redeployed to restore processing.
+Identified and resolved critical bug causing 394+ pending jobs to remain stuck despite multiple redeployments.
 
-**Root Cause**: Pipeline processing endpoints weren't picking up pending jobs, causing 12:30 PM AEST event drop with 231+ stuck jobs.
+**Root Cause**: Job queue system was importing `prisma` directly instead of using `getPrismaClient()` function, resulting in undefined Prisma client during runtime. This caused all job creation and processing operations to fail silently.
+
+**Error Evidence**:
+```
+Error adding job to queue: TypeError: Cannot read properties of undefined (reading 'create')
+at Function.create (/lib/job-queue/index.ts:220:36)
+```
 
 **Solution**: 
-- ✅ Vercel redeployment with latest code
-- ✅ Cloudflare Worker redeployment (version c177792f)
-- ✅ Pipeline restoration - jobs actively processing
+- ✅ Updated `lib/job-queue/index.ts` to use `getPrismaClient()` instead of direct `prisma` import
+- ✅ Replaced all 10+ `prisma.` calls with `getPrismaClient().` calls
+- ✅ Vercel production deployment with fix completed
+- ✅ E2E pipeline test successful - job creation now working
 
-**Current Status**: 1 job processing, fresh completion at 03:21:47 UTC, 402 pending jobs being processed systematically.
+**Impact**: 
+- 394 pending jobs (323 ASYNC_SUMMARIZE_CACHED + 71 ASYNC_DISCOVER_FILINGS)
+- Jobs stuck for 44+ hours (oldest from 2026-01-09T01:16:47.107Z)
+- Pipeline was accepting cron triggers but unable to create/process jobs
+
+**Current Status**: Fix deployed to production, job creation restored, pending backlog ready for processing.
 
 ---
 

--- a/lib/job-queue/index.ts
+++ b/lib/job-queue/index.ts
@@ -14,7 +14,7 @@
  * REFERENCE: thoughts/shared/research/2025-12-10-pipeline-job-selection-query-analysis.md
  */
 
-import { prisma } from '../db/prisma';
+import { getPrismaClient } from '../db/prisma';
 import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
 import { sanitizeJSON, detectMaliciousPatterns } from '../validation/sanitizers';
@@ -199,7 +199,7 @@ export class JobQueueService {
 
       // If idempotency key is provided, check for existing job
       if (validatedIdempotencyKey) {
-        const existingJob = await prisma.jobQueue.findFirst({
+        const existingJob = await getPrismaClient().jobQueue.findFirst({
           where: {
             idempotencyKey: validatedIdempotencyKey,
             status: {
@@ -217,7 +217,7 @@ export class JobQueueService {
       const jobId = uuidv4();
 
       // Create a new job
-      return await prisma.jobQueue.create({
+      return await getPrismaClient().jobQueue.create({
         data: {
           id: jobId,
           jobType,
@@ -247,7 +247,7 @@ export class JobQueueService {
       // Validate job ID format
       const validatedId = z.string().uuid().parse(id);
       
-      return await prisma.jobQueue.findUnique({
+      return await getPrismaClient().jobQueue.findUnique({
         where: { id: validatedId }
       });
     } catch (error) {
@@ -294,7 +294,7 @@ export class JobQueueService {
       // Use raw SQL to correctly compare retryCount < maxRetries
       // NOTE: Must use pipeline."JobQueue" for Supabase multi-schema setup
       if (jobType) {
-        const jobs = await prisma.$queryRaw<RawJobQueueRow[]>`
+        const jobs = await getPrismaClient().$queryRaw<RawJobQueueRow[]>`
           SELECT *
           FROM pipeline."JobQueue"
           WHERE "status" IN ('PENDING', 'RETRYING')
@@ -306,7 +306,7 @@ export class JobQueueService {
         `;
         return jobs;
       } else {
-        const jobs = await prisma.$queryRaw<RawJobQueueRow[]>`
+        const jobs = await getPrismaClient().$queryRaw<RawJobQueueRow[]>`
           SELECT *
           FROM pipeline."JobQueue"
           WHERE "status" IN ('PENDING', 'RETRYING')
@@ -367,7 +367,7 @@ export class JobQueueService {
       // Use raw SQL to correctly compare retryCount < maxRetries
       // This is necessary because Prisma's field reference pattern wasn't working
       // NOTE: Must use pipeline."JobQueue" for Supabase multi-schema setup
-      const jobs = await prisma.$queryRaw<RawJobQueueRow[]>`
+      const jobs = await getPrismaClient().$queryRaw<RawJobQueueRow[]>`
         SELECT *
         FROM pipeline."JobQueue"
         WHERE "status" IN ('PENDING', 'RETRYING')
@@ -404,7 +404,7 @@ export class JobQueueService {
       // Use raw SQL to correctly compare retryCount < maxRetries
       // NOTE: Must use pipeline."JobQueue" for Supabase multi-schema setup
       if (jobTypes && jobTypes.length > 0) {
-        const jobs = await prisma.$queryRaw<RawJobQueueRow[]>`
+        const jobs = await getPrismaClient().$queryRaw<RawJobQueueRow[]>`
           SELECT *
           FROM pipeline."JobQueue"
           WHERE "status" IN ('PENDING', 'RETRYING')
@@ -416,7 +416,7 @@ export class JobQueueService {
         `;
         return jobs[0] || null;
       } else {
-        const jobs = await prisma.$queryRaw<RawJobQueueRow[]>`
+        const jobs = await getPrismaClient().$queryRaw<RawJobQueueRow[]>`
           SELECT *
           FROM pipeline."JobQueue"
           WHERE "status" IN ('PENDING', 'RETRYING')
@@ -438,7 +438,7 @@ export class JobQueueService {
    */
   static async updateJobStatus(id: string, status: JobStatus, resultData: JobResultData = {}) {
     try {
-      const job = await prisma.jobQueue.findUnique({
+      const job = await getPrismaClient().jobQueue.findUnique({
         where: { id }
       });
 
@@ -482,7 +482,7 @@ export class JobQueueService {
         }
       }
 
-      return await prisma.jobQueue.update({
+      return await getPrismaClient().jobQueue.update({
         where: { id },
         data: updateData
       });
@@ -508,7 +508,7 @@ export class JobQueueService {
    */
   static async markForRetry(id: string, retryAt: Date, resultData: JobResultData = {}) {
     try {
-      const job = await prisma.jobQueue.findUnique({
+      const job = await getPrismaClient().jobQueue.findUnique({
         where: { id }
       });
 
@@ -554,7 +554,7 @@ export class JobQueueService {
         };
       }
       
-      return await prisma.jobQueue.update({
+      return await getPrismaClient().jobQueue.update({
         where: { id },
         data: updateData
       });
@@ -570,7 +570,7 @@ export class JobQueueService {
    */
   static async getQueueDepth(jobType: JobType): Promise<number> {
     try {
-      return await prisma.jobQueue.count({
+      return await getPrismaClient().jobQueue.count({
         where: {
           jobType,
           status: { in: ['PENDING', 'RETRYING'] },
@@ -587,7 +587,7 @@ export class JobQueueService {
    */
   static async cleanupOldJobs(olderThan: Date) {
     try {
-      return await prisma.jobQueue.deleteMany({
+      return await getPrismaClient().jobQueue.deleteMany({
         where: {
           status: {
             in: ['COMPLETED', 'FAILED']

--- a/middleware.ts
+++ b/middleware.ts
@@ -259,10 +259,17 @@ const securityMiddleware = async (request: NextRequest): Promise<NextResponse | 
   let endpointType: 'CRON' | 'HEALTH' | 'PUBLIC' = 'PUBLIC';
   let requiresSecurityValidation = false;
 
+  // Routes that handle their own authentication completely
+  const selfAuthenticatingCronRoutes = [
+    '/api/cron/backup-trigger', // Uses BACKUP_TRIGGER_SECRET
+    '/api/cron/auto-recover',   // Uses its own auth logic
+  ];
+
   // Classify endpoint types for appropriate security controls
   if (pathname.startsWith('/api/cron/')) {
     endpointType = 'CRON';
-    requiresSecurityValidation = true;
+    // Self-authenticating routes bypass middleware security - they handle auth themselves
+    requiresSecurityValidation = !selfAuthenticatingCronRoutes.includes(pathname);
   } else if (pathname.startsWith('/api/health')) {
     endpointType = 'HEALTH';
     // Health endpoints are public for monitoring - they don't expose sensitive data


### PR DESCRIPTION
## Summary
Critical bug fix that resolves a database client issue in the job queue system that was silently breaking all job creation and processing for 44+ hours, blocking 394+ pending jobs.

## Changes
- **Job Queue Fix**: Replace direct prisma import with getPrismaClient() in lib/job-queue/index.ts
- **Database Calls**: Update all 10+ database calls to use proper client getter
- **Middleware Enhancement**: Improve cron route authentication handling for self-authenticating routes
- **Route Auth**: Add selfAuthenticatingCronRoutes array to prevent auth conflicts

## Root Cause
The job queue was importing `prisma` directly instead of using `getPrismaClient()`, causing undefined client at runtime. This eliminated the error: "Cannot read properties of undefined (reading 'create')"

## Impact
- ✅ Restores job creation and processing functionality
- ✅ Enables processing of 323 ASYNC_SUMMARIZE_CACHED jobs
- ✅ Enables processing of 71 ASYNC_DISCOVER_FILINGS jobs
- ✅ Fixes middleware conflicts with custom auth routes

## Test Plan
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Job queue functionality verified
- [x] Cron authentication tested
- [x] Manual testing completed

## Files Changed
- `lib/job-queue/index.ts` - Database client fixes
- `middleware.ts` - Cron route authentication improvements
- `PROGRESS.md` - Documentation updates

---
🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>