### PR TITLE
Fix Stripe webhook planType sync and improve checkout UX

### DIFF
--- a/app/api/user/subscription/route.ts
+++ b/app/api/user/subscription/route.ts
@@ -311,7 +311,7 @@ export async function POST(request: NextRequest) {
     const session = await createCheckoutSession({
       priceId,
       customerId: stripeCustomerId,
-      successUrl: `${appUrl}/dashboard/billing?success=true&session_id={CHECKOUT_SESSION_ID}`,
+      successUrl: `${appUrl}/dashboard?subscription_success=true&session_id={CHECKOUT_SESSION_ID}`,
       cancelUrl: `${appUrl}/dashboard/billing?canceled=true`,
       metadata: {
         userId,

--- a/app/api/webhook/stripe/route.ts
+++ b/app/api/webhook/stripe/route.ts
@@ -11,10 +11,33 @@ import Stripe from 'stripe';
 
 const prisma = getPrismaClient();
 
+/**
+ * Derive plan type from Stripe price ID
+ * Returns FREE if price ID doesn't match any configured plan
+ */
+function getPlanTypeFromPriceId(priceId: string | undefined): 'FREE' | 'PRO' | 'MAX' {
+  if (!priceId) return 'FREE';
+
+  const proMonthlyPriceId = process.env.STRIPE_PRO_MONTHLY_PRICE_ID;
+  const proAnnualPriceId = process.env.STRIPE_PRO_ANNUAL_PRICE_ID;
+  const maxMonthlyPriceId = process.env.STRIPE_MAX_MONTHLY_PRICE_ID;
+  const maxAnnualPriceId = process.env.STRIPE_MAX_ANNUAL_PRICE_ID;
+
+  if (priceId === proMonthlyPriceId || priceId === proAnnualPriceId) {
+    return 'PRO';
+  }
+  if (priceId === maxMonthlyPriceId || priceId === maxAnnualPriceId) {
+    return 'MAX';
+  }
+
+  return 'FREE';
+}
+
 export async function POST(request: NextRequest) {
   try {
     const body = await request.text();
-    const signature = headers().get('stripe-signature');
+    const headersList = await headers();
+    const signature = headersList.get('stripe-signature');
 
     if (!signature) {
       console.error('Missing Stripe signature');
@@ -86,7 +109,7 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
   }
 
   const userId = session.metadata?.userId;
-  const planType = session.metadata?.planType;
+  const planType = session.metadata?.planType as 'FREE' | 'PRO' | 'MAX' | undefined;
 
   if (!userId || !planType) {
     console.error('Missing metadata in checkout session');
@@ -94,10 +117,11 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
   }
 
   try {
-    // Update subscription record
+    // Update subscription record with planType, subscription ID, and active status
     await prisma.userSubscription.update({
       where: { userId },
       data: {
+        planType, // Update the plan type from checkout metadata
         stripeSubscriptionId: session.subscription as string,
         isActive: true,
         updatedAt: new Date(),
@@ -163,10 +187,14 @@ async function handleSubscriptionCreated(subscription: Stripe.Subscription) {
   }
 
   try {
-    // Update subscription with Stripe data
+    // Derive plan type from price ID
+    const planType = getPlanTypeFromPriceId(priceId);
+
+    // Update subscription with Stripe data including planType
     await prisma.userSubscription.update({
       where: { userId: userSubscription.userId },
       data: {
+        planType,
         stripeSubscriptionId: subscription.id,
         stripePriceId: priceId,
         isActive: subscription.status === 'active',
@@ -177,7 +205,7 @@ async function handleSubscriptionCreated(subscription: Stripe.Subscription) {
       },
     });
 
-    console.log(`Subscription created for user ${userSubscription.userId}`);
+    console.log(`Subscription created for user ${userSubscription.userId}, plan: ${planType}`);
   } catch (error) {
     console.error('Failed to process subscription creation:', error);
   }
@@ -198,10 +226,13 @@ async function handleSubscriptionUpdated(subscription: Stripe.Subscription) {
 
   try {
     const priceId = subscription.items.data[0]?.price.id;
+    // Derive plan type from price ID for subscription changes (upgrades/downgrades)
+    const planType = getPlanTypeFromPriceId(priceId);
 
     await prisma.userSubscription.update({
       where: { userId: userSubscription.userId },
       data: {
+        planType,
         stripePriceId: priceId,
         isActive: subscription.status === 'active',
         currentPeriodStart: new Date(subscription.current_period_start * 1000),
@@ -211,7 +242,7 @@ async function handleSubscriptionUpdated(subscription: Stripe.Subscription) {
       },
     });
 
-    console.log(`Subscription updated for user ${userSubscription.userId}`);
+    console.log(`Subscription updated for user ${userSubscription.userId}, plan: ${planType}`);
   } catch (error) {
     console.error('Failed to process subscription update:', error);
   }
@@ -234,13 +265,14 @@ async function handleSubscriptionDeleted(subscription: Stripe.Subscription) {
     await prisma.userSubscription.update({
       where: { userId: userSubscription.userId },
       data: {
+        planType: 'FREE', // Revert to free tier on cancellation
         isActive: false,
         cancelAtPeriodEnd: false,
         updatedAt: new Date(),
       },
     });
 
-    console.log(`Subscription cancelled for user ${userSubscription.userId}`);
+    console.log(`Subscription cancelled for user ${userSubscription.userId}, reverted to FREE`);
   } catch (error) {
     console.error('Failed to process subscription deletion:', error);
   }

--- a/app/dashboard/billing/page.tsx
+++ b/app/dashboard/billing/page.tsx
@@ -8,6 +8,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -19,11 +20,11 @@ import {
   ArrowRight,
   AlertTriangle,
   Zap,
-  Shield,
   Clock,
   Users
 } from 'lucide-react';
-import { formatDistanceToNow, format } from 'date-fns';
+import { toast } from 'sonner';
+import { format } from 'date-fns';
 import { useUser } from '@clerk/nextjs';
 import { SUBSCRIPTION_PLANS, type PlanType } from '@/lib/stripe/plans';
 
@@ -81,10 +82,30 @@ interface UserSubscription {
 
 export default function BillingPage() {
   const { user } = useUser();
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const [subscription, setSubscription] = useState<UserSubscription | null>(null);
   const [loading, setLoading] = useState(true);
   const [updating, setUpdating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Handle checkout cancellation - redirect to dashboard
+  useEffect(() => {
+    if (searchParams.get('canceled') === 'true') {
+      router.replace('/dashboard');
+    }
+  }, [searchParams, router]);
+
+  // Handle checkout success - show toast and redirect to dashboard
+  useEffect(() => {
+    if (searchParams.get('success') === 'true') {
+      toast.success('Payment successful!', {
+        description: 'Your subscription has been activated.',
+        duration: 5000,
+      });
+      router.replace('/dashboard?subscription_success=true');
+    }
+  }, [searchParams, router]);
 
   useEffect(() => {
     async function fetchSubscription() {
@@ -231,7 +252,7 @@ export default function BillingPage() {
 
       {/* Current Subscription Status */}
       {subscription && (
-        <Card>
+        <Card className="border-0 shadow-sm bg-gray-50">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <CreditCard className="h-5 w-5" />
@@ -239,33 +260,20 @@ export default function BillingPage() {
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            <div className="flex items-center justify-between">
-              <div>
-                <h3 className="font-semibold text-lg">
-                  {currentPlanConfig?.name || 'Unknown Plan'}
-                </h3>
-                <p className="text-gray-600">
-                  {currentBillingPlan?.price || 'Price unavailable'}
-                </p>
-              </div>
-              <Badge variant={subscription.isActive ? 'default' : 'destructive'}>
-                {subscription.isActive ? 'Active' : 'Inactive'}
-              </Badge>
+            <div>
+              <h3 className="font-semibold text-lg">
+                {currentPlanConfig?.name || 'Unknown Plan'}
+              </h3>
+              <p className="text-gray-600">
+                {currentBillingPlan?.price || 'Price unavailable'}
+              </p>
             </div>
 
-            <div className="grid grid-cols-2 gap-4 text-sm">
-              <div>
-                <p className="text-gray-500">Billing Period</p>
-                <p className="font-medium">
-                  Renews {formatDistanceToNow(new Date(subscription.currentPeriodEnd), { addSuffix: true })}
-                </p>
-              </div>
-              <div>
-                <p className="text-gray-500">Companies Tracked</p>
-                <p className="font-medium">
-                  {currentBillingPlan?.tickerDisplay || 'Unknown'}
-                </p>
-              </div>
+            <div className="text-sm">
+              <p className="text-gray-500">Billing Period</p>
+              <p className="font-medium">
+                Renews on {format(new Date(subscription.currentPeriodEnd), 'MMMM d, yyyy')}
+              </p>
             </div>
 
             {subscription.cancelAtPeriodEnd && (
@@ -306,12 +314,15 @@ export default function BillingPage() {
       <div>
         <h2 className="text-2xl font-semibold mb-6">Available Plans</h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          {billingPlans.map((plan) => (
+          {billingPlans.map((plan) => {
+            // Only show "Recommended" badge for Pro plan if user is on FREE tier
+            const showRecommended = plan.recommended && currentPlanKey === 'FREE';
+            return (
             <Card
               key={plan.planKey}
-              className={`relative landing-card ${plan.recommended ? 'ring-2 ring-[var(--landing-primary)] shadow-lg' : ''}`}
+              className={`relative landing-card flex flex-col ${showRecommended ? 'ring-2 ring-[var(--landing-primary)] shadow-lg' : ''}`}
             >
-              {plan.recommended && (
+              {showRecommended && (
                 <div className="absolute -top-3 left-1/2 transform -translate-x-1/2">
                   <Badge className="bg-[var(--landing-primary)] hover:bg-[var(--landing-primary-hover)]">
                     Recommended
@@ -320,18 +331,15 @@ export default function BillingPage() {
               )}
 
               <CardHeader>
-                <CardTitle className="flex items-center justify-between">
+                <CardTitle>
                   {plan.name}
-                  {currentPlanKey === plan.planKey && (
-                    <Badge variant="outline">Current</Badge>
-                  )}
                 </CardTitle>
                 <CardDescription>
                   <span className="text-2xl font-bold text-gray-900">{plan.price}</span>
                 </CardDescription>
               </CardHeader>
 
-              <CardContent className="space-y-4">
+              <CardContent className="space-y-4 flex flex-col flex-grow">
                 <div className="space-y-2">
                   <div className="flex items-center gap-2 text-sm">
                     <Users className="h-4 w-4 text-gray-500" />
@@ -345,7 +353,7 @@ export default function BillingPage() {
 
                 <Separator />
 
-                <ul className="space-y-2">
+                <ul className="space-y-2 flex-grow">
                   {plan.features.map((feature, index) => {
                     // Convert markdown-style bold (**text**) to proper semantic HTML
                     const parts = feature.split(/\*\*([^*]+)\*\*/g);
@@ -353,7 +361,7 @@ export default function BillingPage() {
                       <li key={index} className="flex items-center gap-2 text-sm">
                         <CheckCircle className="h-3 w-3 text-green-500 flex-shrink-0" />
                         <span>
-                          {parts.map((part, partIndex) => 
+                          {parts.map((part, partIndex) =>
                             partIndex % 2 === 1 ? (
                               <strong key={partIndex}>{part}</strong>
                             ) : (
@@ -366,33 +374,31 @@ export default function BillingPage() {
                   })}
                 </ul>
 
-                <Button
-                  className="w-full"
-                  variant={currentPlanKey === plan.planKey ? 'outline' : 'default'}
-                  disabled={currentPlanKey === plan.planKey || updating}
-                  onClick={() => handlePlanChange(plan.planKey)}
-                >
-                  {currentPlanKey === plan.planKey ? 'Current Plan' : (plan.planKey === 'FREE' ? 'Downgrade' : 'Upgrade')}
-                  {currentPlanKey !== plan.planKey && <ArrowRight className="h-4 w-4 ml-2" />}
-                </Button>
+                {(() => {
+                  const isCurrentPlan = currentPlanKey === plan.planKey;
+                  const planOrder = { FREE: 0, PRO: 1, MAX: 2 };
+                  const currentOrder = currentPlanKey ? planOrder[currentPlanKey] : 0;
+                  const targetOrder = planOrder[plan.planKey];
+                  const isDowngrade = targetOrder < currentOrder;
+
+                  return (
+                    <Button
+                      className="w-full border mt-auto"
+                      variant={isCurrentPlan ? 'outline' : 'outline'}
+                      disabled={isCurrentPlan || updating}
+                      onClick={() => handlePlanChange(plan.planKey)}
+                    >
+                      {isCurrentPlan ? 'Current Plan' : (isDowngrade ? 'Downgrade' : 'Upgrade')}
+                      {!isCurrentPlan && <ArrowRight className="h-4 w-4 ml-2" />}
+                    </Button>
+                  );
+                })()}
               </CardContent>
             </Card>
-          ))}
+          );
+          })}
         </div>
       </div>
-
-      {/* Security Notice */}
-      <Card className="bg-blue-50 border-blue-200">
-        <CardContent className="pt-6">
-          <div className="flex items-center gap-2 text-blue-800 mb-2">
-            <Shield className="h-4 w-4" />
-            <span className="font-medium">Secure Billing</span>
-          </div>
-          <p className="text-sm text-blue-700">
-            All payments are processed securely through Stripe. We never store your payment information on our servers.
-          </p>
-        </CardContent>
-      </Card>
     </div>
   );
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -16,6 +16,7 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
   const params = await searchParams;
   const showWelcome = params.welcome === 'true';
   const shouldMergePending = params.merge === 'pending' || showWelcome;
+  const subscriptionSuccess = params.subscription_success === 'true';
 
-  return <DashboardClient showWelcome={showWelcome} shouldMergePending={shouldMergePending} />;
+  return <DashboardClient showWelcome={showWelcome} shouldMergePending={shouldMergePending} subscriptionSuccess={subscriptionSuccess} />;
 }

--- a/components/dashboard/dashboard-client.tsx
+++ b/components/dashboard/dashboard-client.tsx
@@ -35,9 +35,10 @@ import {
 interface DashboardClientProps {
   showWelcome?: boolean;
   shouldMergePending?: boolean;
+  subscriptionSuccess?: boolean;
 }
 
-export function DashboardClient({ showWelcome = false, shouldMergePending = false }: DashboardClientProps) {
+export function DashboardClient({ showWelcome = false, shouldMergePending = false, subscriptionSuccess = false }: DashboardClientProps) {
   // State for tracked companies
   const [companies, setCompanies] = useState<Company[]>([]);
   const [currentCompany, setCurrentCompany] = useState<Company | null>(null);
@@ -130,6 +131,16 @@ export function DashboardClient({ showWelcome = false, shouldMergePending = fals
       setTutorialProgress(parseInt(savedProgress, 10));
     }
   }, [loadCompanies, showWelcome]);
+
+  // Show success toast when subscription is activated
+  useEffect(() => {
+    if (subscriptionSuccess) {
+      toast.success('Welcome to your new plan!', {
+        description: 'Your subscription is now active. Start tracking more companies!',
+        duration: 5000,
+      });
+    }
+  }, [subscriptionSuccess]);
 
   // Lazy-load companies for search - only fetch when user clicks Add Ticker
   const loadCompaniesForSearch = useCallback(async () => {

--- a/components/landing/sections-v2/pricing-section-v2.tsx
+++ b/components/landing/sections-v2/pricing-section-v2.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Check, Zap, Sparkles, Crown, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
 import {
   staggerContainer,
   staggerItem,
@@ -137,14 +138,33 @@ export function PricingSectionV2() {
 
       const data = await response.json();
 
+      if (!response.ok) {
+        if (response.status === 409) {
+          // User already has an active subscription
+          toast.error('You already have an active subscription', {
+            description: 'Visit your billing page to manage or upgrade your plan.',
+            action: {
+              label: 'Go to Billing',
+              onClick: () => router.push('/dashboard/billing'),
+            },
+          });
+        } else {
+          toast.error(data.error || 'Failed to create checkout session');
+        }
+        setLoadingPlan(null);
+        return;
+      }
+
       if (data.checkoutUrl) {
         window.location.href = data.checkoutUrl;
       } else {
         console.error('No checkout URL returned:', data);
+        toast.error('Failed to start checkout. Please try again.');
         setLoadingPlan(null);
       }
     } catch (error) {
       console.error('Error creating checkout session:', error);
+      toast.error('An error occurred. Please try again.');
       setLoadingPlan(null);
     }
   };


### PR DESCRIPTION
## Summary

This PR addresses critical issues with the Stripe integration where user plan types were not being properly synchronized after checkout, and improves the post-checkout user experience.

## Changes

### Backend - Stripe Webhook Improvements
- Add `getPlanTypeFromPriceId` helper to derive plan type from Stripe price IDs
- Fix `handleCheckoutCompleted` to persist planType from checkout metadata
- Fix `handleSubscriptionCreated` to derive and save planType from price ID
- Fix `handleSubscriptionUpdated` to update planType on plan changes (upgrades/downgrades)
- Fix `handleSubscriptionDeleted` to revert planType to FREE on cancellation
- Fix async `headers()` call for Next.js 15 compatibility

### Frontend - Checkout Flow UX
- Redirect checkout success to `/dashboard` instead of `/billing` page
- Add `subscription_success` URL param to trigger success toast on dashboard
- Show "Welcome to your new plan!" toast with guidance for new subscribers
- Redirect billing page canceled/success states to dashboard

### UI Improvements
- Simplify billing page layout (remove redundant status badge, security card)
- Show "Recommended" badge only for FREE tier users viewing Pro plan
- Make plan cards use flex layout for consistent button positioning
- Add toast notifications for pricing section checkout errors with actionable buttons

## Test Plan
- [ ] Unit tests pass
- [ ] Webhook handles all subscription events correctly
- [ ] Checkout success redirects to dashboard with toast
- [ ] Checkout cancellation redirects to dashboard
- [ ] Billing page displays correctly for all plan states
- [ ] Pricing section shows appropriate error toasts

## Technical Details
- Ensures database `planType` stays in sync with Stripe subscription state
- Fixes issue where users remained on FREE tier after completing checkout
- Provides better error feedback for edge cases (existing subscription, API failures)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>