### PR TITLE
Fix trial service user lookup with authProviderId support

### DIFF
--- a/.claude/history/TIMELINE.md
+++ b/.claude/history/TIMELINE.md
@@ -13,7 +13,11 @@ This file provides a chronological index of all completed projects. For detailed
 
 | Date | Project | Status |
 |------|---------|--------|
+| 2026-02-12 | TrialService User Lookup Fix (findFirst with authProviderId, graceful fallback) | 🔄 |
+| 2026-02-12 | Cloudflare Cron Schedule Consolidation (fit free tier limit) | ✅ |
+| 2026-02-11 | FREE Plan to 7-Day Trial Migration (database-managed trial, 8 phases, email gates) | ✅ |
 | 2026-02-10 | Pipeline Job Processing Improvements (DLQ cleanup automation, retry pattern docs, test fixes) | ✅ |
+| 2026-02-07 | Subscription Management UX Redesign (Grok-inspired interface, PR #343) | ✅ |
 | 2026-02-07 | Dashboard Loading Skeleton Enhancement (animations, shimmer, Card components, Playwright validation) | ✅ |
 | 2026-02-07 | Dashboard UI Polish (Manage Subscription button border removal) | ✅ |
 | 2026-02-07 | Orphaned UserSubscription Database Cleanup (dashboard loading fix, 2 orphaned records deleted) | ✅ |
@@ -24,8 +28,10 @@ This file provides a chronological index of all completed projects. For detailed
 | 2026-01-27 | Unsent Email Recovery (47 completed summaries resent, scripts created) | ✅ |
 | 2026-01-27 | TickerMonitoring Root Cause Fix (3-phase pipeline missing upsert, health endpoint enhancement) | ✅ |
 | 2026-01-27 | GitHub Actions Minutes Optimization (watchdog */30, path filters for quality-gates + pr-validation) | ✅ |
+| 2026-01-26 | Stripe Webhook planType Sync Fix (PR #339, checkout UX improvements) | ✅ |
 | 2026-01-26 | Pipeline Resilience Zero-Intervention (CRON_SECRET sanitization, orphan detection, GitHub Action watchdog) | ✅ |
 | 2026-01-25 | Stripe CTA Dashboard Integration (UpgradeCTASection + direct Stripe checkout, $199/$349 pricing) | ✅ |
+| 2026-01-23 | Prospectus Filing Type Preferences (424B2 filtering, email volume reduction, PR #335) | ✅ |
 | 2026-01-21 | Cloudflare Build Fix - Onboarding Dynamic Rendering (force-dynamic export, client/server split) | ✅ |
 | 2026-01-20 | Pipeline Health Connection Pool Exhaustion Fix (caching, aggregated SQL, orphan sampling, batching) | ✅ |
 | 2026-01-19 | Onboarding Redirect Race Condition Fix (email await + cookie bypass for Clerk JWT sync) | ✅ |
@@ -175,11 +181,10 @@ This file provides a chronological index of all completed projects. For detailed
 
 ## Archive Statistics
 - **Total Archived Projects**: 11 weekly archives (Oct-Dec 2025)
-- **Current PROGRESS.md Lines**: 727 (threshold: 500) ⚠️ 227 LINES OVER
-- **Last Sync**: 2026-02-10
+- **Current PROGRESS.md Lines**: 263 (threshold: 500) ✅ HEALTHY
+- **Last Sync**: 2026-02-12
 - **Archive System**: ✅ ACTIVE
-- **Last Compaction**: 2026-02-10 (No archival - all projects < 30 days old, structural cleanup performed)
-- **Note**: File is 227 lines over threshold but no projects qualify for archival (oldest: 2026-01-25, needs 30+ days). Duplicate "Recently Completed Sessions" header removed.
+- **Last Compaction**: 2026-02-12 (No archival needed — 263 lines, all projects < 30 days old)
 
 **Archives**:
 - `29-Dec-2025.md` - Cloudflare Cron Fix, Email Quality, Form 4 Templates, JSON Parsing Phase 5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 6. **Run tests before committing** - See Pre-Commit Testing section for mandatory tests
 7. **Never store API keys in shell config** - API keys belong in `.env.local` files (gitignored), not `.zshrc` or `.bashrc` where they can be exposed or committed to version control
 8. **Define CSS animations explicitly** - Don't rely on Tailwind auto-generation for custom animations. Define keyframes and animation classes in `app/globals.css` using `@layer utilities` to ensure they're always available
+9. **Look up users by `authProviderId` not just `id`** - Clerk `userId` is stored in `authProviderId`, not the DB `id` field. Use `findFirst({ where: { OR: [{ id }, { authProviderId }] } })` or look up by email. See tickers route pattern: `app/api/user/tickers/route.ts`
 
 ### Pattern References
 When implementing new features, reference these exemplar files:

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,714 +1,252 @@
 # Project Progress
 
-**Date**: 2026-02-10
-**Branch**: investigation/pipeline-job-processing-2026-02-09
-**Status**: Pipeline Job Processing Improvements Complete
+**Date**: 2026-02-12
+**Branch**: main
+**Status**: Trial System Live + TrialService Lookup Fix
 
 ---
 
-## Current Session: Pipeline Job Processing Improvements ✅ (2026-02-10)
+## Current Session
 
-**Goal**: Implement operational excellence improvements from pipeline investigation - DLQ cleanup automation, retry pattern documentation, and test suite fixes.
+### TrialService User Lookup Fix (2026-02-12)
 
-**Context**: Following the 2026-02-09 pipeline investigation, identified three improvement areas: (1) DLQ growth with no automated cleanup, (2) undocumented retry patterns (100% jobs have retryCount=1 due to cold starts), (3) test suite failures blocking CI/CD.
+**Problem**: `/api/user/subscription` returning 500 — `TrialService.checkTrialStatus()` looked up users by `where: { id: userId }` but Clerk `userId` is stored in `authProviderId`, not `id`.
 
-### Phase 1: Retry Pattern Documentation ✅
+**Fix**: Changed `findUnique({ where: { id } })` to `findFirst({ where: { OR: [{ id }, { authProviderId }] } })` in `lib/auth/trial-service.ts`. Also made it return a default active/grandfathered status instead of throwing when user isn't in DB yet (user gets auto-created on first `/api/user/tickers` call).
 
-**Problem**: 100% of successful jobs showing retryCount=1 - appeared concerning but is actually expected behavior due to serverless cold starts.
-
-**Root Cause**: Vercel serverless functions experience 5-13 seconds of initialization overhead (function + database + Prisma), causing initial attempts to timeout. By retry time (1 minute later), all resources are warm.
-
-**Implementation**:
-1. **Created Architecture Documentation** (`docs/architecture/job-retry-patterns.md`):
-   - 200+ line comprehensive explanation of cold start patterns
-   - Performance metrics from investigation (75-104s processing time)
-   - Anomaly detection thresholds (>10% retryCount>1)
-   - Potential optimizations (function warming, connection pooling)
-
-2. **Implemented Monitoring Service** (`lib/monitoring/retry-rate-monitor.ts`):
-   - `getMetrics()` - Track retry patterns and detect anomalies
-   - `getHealth()` - Comprehensive health assessment with recommendations
-   - `getDetailedBreakdown()` - Debugging tool for retry investigation
-
-3. **Created Dashboard Endpoint** (`app/api/monitoring/retry-rates/route.ts`):
-   - Publicly accessible health metrics
-   - Query parameters: `?hours=48&detailed=true`
-   - Returns: healthy status, retry distribution, anomaly detection
-
-4. **Updated CLAUDE.md** - Added retry patterns section with monitoring commands
-
-**Files Created**:
-- `docs/architecture/job-retry-patterns.md` (~200 lines)
-- `lib/monitoring/retry-rate-monitor.ts` (~290 lines)
-- `app/api/monitoring/retry-rates/route.ts` (~150 lines)
-- `__tests__/lib/monitoring/retry-rate-monitor.test.ts` (12 passing tests)
-
-**Verification**:
-- ✅ All 12 retry rate monitor tests passing
-- ✅ Baseline established: 100% retryCount=1 is normal
-- ✅ Anomaly threshold set: >10% retryCount>1
-- ✅ Documentation complete with investigation metrics
-
-**Impact**: Future agents understand retryCount=1 is expected, not a bug. Monitoring alerts only on actual anomalies.
-
----
-
-### Phase 2: Test Suite Fixes ✅
-
-**Problem**: Multiple test failures blocking CI/CD - email masking expectations, database transaction tests, and mock structure issues.
-
-**Fixes Applied**:
-
-1. **Email Masking Test** (`__tests__/lib/email/async-email-queue.test.ts`):
-   - Updated expectation for 2-char emails: `ab@test.com` → `ab***@test.com`
-   - Implementation intentionally shows both chars for debugging
-   - Comment added explaining why this is correct behavior
-
-2. **Database Transaction Tests** - Fixed 2 tests with wrong expectations:
-   - **Test 1**: "Email sent + final COMPLETED status fails" → Should count as processed (email delivered)
-   - **Test 2**: "Initial PROCESSING status fails" → Implementation continues anyway (resilient design)
-   - Updated expectations to match actual implementation behavior at lines 350-355 and 375-376
-
-3. **Mock Structure** - All mocks correctly configured with jest.spyOn pattern
-
-**Files Modified**:
-- `__tests__/lib/email/async-email-queue.test.ts` - Fixed 3 test expectations
-
-**Verification**:
-- ✅ async-email-queue tests: 57 passing (was 55 failing)
-- ✅ security-helpers tests: 49 passing
-- ✅ content-validation tests: 87 passing
-- ✅ CI/CD pipeline unblocked
-
-**Impact**: Test suite now reflects actual implementation behavior. Tests validate resilient design (email delivery prioritized over status tracking).
-
----
-
-### Phase 3: DLQ Automated Cleanup ✅
-
-**Problem**: 20 old failed jobs (12+ days old) accumulating in DLQ with no automated cleanup mechanism.
-
-**Implementation**:
-
-1. **Created Cleanup Endpoint** (`app/api/cron/cleanup-dlq/route.ts`):
-   - Removes reprocessed DLQ entries >30 days old
-   - Archives FAILED jobs >14 days old from main JobQueue
-   - Reports DLQ metrics (size, error patterns, age distribution)
-   - Triggers alerts at thresholds (50=WARNING, 100=CRITICAL)
-   - HMAC authentication via CronAuthService
-   - Integrated with CronJobMonitor for execution tracking
-
-2. **Created Monitoring Dashboard** (`app/api/monitoring/dlq-status/route.ts`):
-   - Publicly accessible DLQ health metrics
-   - Returns: pending count, reprocessed count, error patterns, age distribution
-   - Health status: HEALTHY (<50), WARNING (50-99), CRITICAL (≥100)
-   - Recent entries preview with 5 most recent DLQ items
-
-3. **Updated Cloudflare Worker** (`cloudflare-cron/index.js`):
-   - Added routing for `0 2 * * *` cron schedule (2 AM UTC daily)
-   - Implemented `handleDLQCleanup()` handler with HMAC signature generation
-   - Added dlqCleanup to handlerHealth tracking object
-   - Integrated with Slack alerting for CRITICAL DLQ size
-
-4. **Updated Documentation** (`CLAUDE.md`):
-   - Added "Dead Letter Queue Management" section
-   - Documented automatic cleanup schedule and manual trigger commands
-   - Added health status thresholds and monitoring commands
-
-**Files Created**:
-- `app/api/cron/cleanup-dlq/route.ts` (~250 lines)
-- `app/api/monitoring/dlq-status/route.ts` (~150 lines)
-- `__tests__/api/cron/cleanup-dlq.test.ts` (9 passing tests)
-
-**Files Modified**:
-- `cloudflare-cron/index.js` - Added DLQ cleanup routing and handler
-- `CLAUDE.md` - Added DLQ management section
-
-**Verification**:
-- ✅ All 9 DLQ cleanup tests passing
-- ✅ Cleanup logic validates time cutoffs (14/30 days)
-- ✅ Alert thresholds correctly trigger at 50 and 100 entries
-- ✅ Cloudflare Worker routing configured for 2 AM UTC daily
-- ✅ HMAC authentication working
-
-**Impact**: DLQ will be automatically cleaned daily. Old failed jobs archived. Alerts trigger if DLQ grows beyond healthy levels.
-
----
-
-**Overall Results**:
-- ✅ **Phase 1 Complete**: Retry patterns documented, monitoring in place, baseline established
-- ✅ **Phase 2 Complete**: All test suite failures resolved, CI/CD unblocked
-- ✅ **Phase 3 Complete**: Automated DLQ cleanup deployed, monitoring dashboard live
-
-**Total Implementation**: ~1,200 lines of new code, 21 comprehensive tests (all passing), complete documentation
+**Files**: `lib/auth/trial-service.ts`
 
 ---
 
 ## Recently Completed Sessions
 
+### Cloudflare Cron Schedule Consolidation ✅ (2026-02-12)
+
+**Goal**: Consolidate Cloudflare Worker cron schedules to fit within the free tier limit.
+
+**Files**: `cloudflare-cron/wrangler.toml`, `cloudflare-cron/index.js`
+
+---
+
+### FREE Plan to 7-Day Trial Migration ✅ (2026-02-11)
+
+**Goal**: Replace the permanent FREE plan with a 7-day database-managed trial system. Grandfathered FREE users (signed up before migration) keep permanent free access.
+
+**Architecture Decisions**:
+- **Database-managed trial** (no Stripe `trial_period_days`) - trial tracked entirely in DB
+- **Grandfathered pattern**: `FREE + NULL trialStartedAt` = permanent free, `FREE + trialStartedAt` = 7-day trial
+- **Soft block**: Expired trials can view dashboard but don't receive new emails
+- **Email delivery gate**: Fails open (sends email if trial check fails)
+- **IP abuse prevention**: 3 signups per IP per 30 days, fails open
+
+**Implementation (8 Phases)**:
+
+1. **Database Schema** - Added 4 trial fields to User model + 2 indexes:
+   - `trialStartedAt`, `trialEndsAt`, `isTrialing`, `signupIpAddress`
+   - Migration: `prisma/migrations/20260211_add_trial_fields/migration.sql`
+
+2. **Core Services**:
+   - `lib/auth/trial-config.ts` - TRIAL_CONFIG constants (single source of truth)
+   - `lib/auth/trial-service.ts` - TrialService class (checkTrialStatus, calculateTrialEnd)
+   - `lib/security/trial-abuse-prevention.ts` - IP-based abuse prevention
+
+3. **Webhook Integration** (`app/api/webhook/clerk/route.ts`):
+   - Trial creation with IP abuse check during user signup
+   - Extracts IP from `x-forwarded-for`/`x-real-ip` headers
+
+4. **API & UI**:
+   - `app/api/user/subscription/route.ts` - Added trial data to GET responses
+   - `hooks/use-subscription.ts` - Added trial fields to SubscriptionData interface
+   - `components/dashboard/plan-status-banner.tsx` - Trial countdown with urgency colors (green/orange/red)
+   - `components/dashboard/expired-trial-banner.tsx` - Post-expiration upgrade CTA
+   - `components/dashboard/dashboard-shell.tsx` - Integrated trial banners
+
+5. **Trial Expiration Handling**:
+   - `lib/cron/handlers/trial-expiration-handler.ts` - Marks expired users, sends notification email
+   - `app/api/cron/check-trial-expiration/route.ts` - Daily cron endpoint
+   - `lib/job-queue/index.ts` - Added CHECK_TRIAL_EXPIRATION job type
+   - `lib/cron/background-filing-worker.ts` - Registered handler
+
+6. **Email Templates** (`lib/email/trial-emails.ts`):
+   - `sendTrialWelcomeEmail` - Sent at signup
+   - `sendTrialReminderEmail` - Sent before expiration (urgency-based subject)
+   - `sendTrialExpirationEmail` - Sent when trial ends
+
+7. **Email Delivery Gate** (`lib/cron/handlers/summarize-cached-handler.ts`):
+   - Added `TrialService.checkTrialStatus()` check before all 3 email sending locations
+   - Expired trial users don't receive new filing emails
+
+8. **Configuration Changes**:
+   - `lib/stripe/plans.ts` - FREE plan: `filingTypes: ['ALL']`, `emailFrequency: 'realtime'`
+   - `lib/user/preference-types.ts` - All filing types enabled by default
+   - `cloudflare-cron/wrangler.toml` - Added daily midnight UTC cron for trial expiration
+   - `cloudflare-cron/index.js` - Added trial expiration handler routing
+
+**Pre-existing TS Errors** (not from this migration):
+- `hooks/use-subscription.ts` - `unknown` type errors from `response.json()` (7 errors)
+- `components/billing/subscription-plans.tsx` - Missing `priceId`/`monthlyFilings` properties (6 errors)
+
+**Verification**: Build passes, all trial-related functionality implemented across 8 phases.
+
+---
+
+### Pipeline Job Processing Improvements ✅ (2026-02-10)
+
+**Goal**: Implement operational excellence improvements from pipeline investigation - DLQ cleanup automation, retry pattern documentation, and test suite fixes.
+
+**Phase 1: Retry Pattern Documentation** - 100% of jobs having retryCount=1 is EXPECTED (serverless cold starts). Created:
+- `docs/architecture/job-retry-patterns.md` - Comprehensive cold start analysis
+- `lib/monitoring/retry-rate-monitor.ts` - Anomaly detection (alerts if >10% retryCount>1)
+- `app/api/monitoring/retry-rates/route.ts` - Public health metrics endpoint
+
+**Phase 2: Test Suite Fixes** - Fixed 3 test expectations in `__tests__/lib/email/async-email-queue.test.ts`:
+- Email masking for 2-char emails, database transaction test expectations
+- Result: 57 passing (was 55 failing)
+
+**Phase 3: DLQ Automated Cleanup** - Created daily cleanup at 2 AM UTC:
+- `app/api/cron/cleanup-dlq/route.ts` - Removes old DLQ entries (30d reprocessed, 14d failed)
+- `app/api/monitoring/dlq-status/route.ts` - Health dashboard (HEALTHY/WARNING/CRITICAL thresholds)
+- `cloudflare-cron/index.js` - Added DLQ cleanup handler routing
+
+**Total**: ~1,200 lines new code, 21 tests (all passing)
+
+---
+
 ### Dashboard Loading Skeleton Enhancement ✅ (2026-02-07)
 
-**Goal**: Fix loading skeleton UI issues - remove purple borders, add smooth animations, create seamless loading experience.
+**Problem**: Loading skeleton cards showing purple borders, no animations, content "snapping in".
 
-**Problem**: Loading skeleton cards showing purple borders with blank spaces, no animation effects, content "snapping in" without transitions.
+**Fixes**:
+- `components/ui/skeleton.tsx` - Shimmer animation gradient overlay
+- `app/globals.css` + `tailwind.config.ts` - fadeIn, slideUp, shimmer keyframes
+- `app/dashboard/loading.tsx` - Replaced `landing-card` with shadcn `Card`, staggered animations
+- `components/dashboard/tickers-table/tickers-table-skeleton.tsx` - slideUp animations
 
-**Root Cause**:
-1. Purple borders from custom `landing-card` class with hover effects
-2. Animation classes (`animate-fadeIn`, `animate-slideUp`) not defined in Tailwind config
-3. Skeleton shimmer using arbitrary value syntax not working
+**Note**: Dashboard loads so fast (<500ms) that loading states are barely visible.
 
-**Fixes Applied**:
+---
 
-1. **Enhanced Skeleton Component** (`components/ui/skeleton.tsx`):
-   - Added shimmer animation gradient overlay
-   - Improved contrast with `bg-muted/60`
-   - Created continuous sweeping shimmer effect
+### Subscription Management UX Redesign ✅ (2026-02-07)
 
-2. **Added Animation Keyframes** (`app/globals.css` + `tailwind.config.ts`):
-   - `fadeIn`: 0.5s ease-out opacity transition
-   - `slideUp`: 0.4s ease-out with 10px upward motion
-   - `shimmer`: 2s infinite gradient sweep
-   - Defined in both globals.css (@layer utilities) and Tailwind config for reliability
+**PR**: [#343](https://github.com/wilfred-py/tldrsec-ai/pull/343)
 
-3. **Improved Loading UI** (`app/dashboard/loading.tsx`):
-   - Replaced custom `landing-card` with shadcn `Card` components
-   - Added staggered row animations (50ms delay between rows)
-   - Enhanced visual hierarchy with proper borders and shadows
-   - Added fade-in container animation
-   - Added contextual skeleton cards for complete loading state
-
-4. **Updated Table Skeleton** (`components/dashboard/tickers-table/tickers-table-skeleton.tsx`):
-   - Applied slideUp animations with staggered delays
-   - Enhanced mobile skeleton cards with better spacing
-   - Improved pagination skeleton with button shapes
-
-**Files Modified**:
-- `components/ui/skeleton.tsx` - Shimmer gradient overlay
-- `app/globals.css` - Animation keyframes in @layer utilities
-- `tailwind.config.ts` - Keyframe and animation definitions
-- `app/dashboard/loading.tsx` - Card components + animations
-- `components/dashboard/tickers-table/tickers-table-skeleton.tsx` - Animation classes
-
-**Verification**:
-- ✅ All 3 animations working (fadeIn, slideUp, shimmer) verified via Playwright
-- ✅ Animation properties confirmed: fadeIn (0.5s), slideUp (0.4s), shimmer (2s infinite)
-- ✅ Purple borders removed (shadcn Card components)
-- ✅ Shimmer effect visible and continuous
-- ✅ Build compiles successfully
-
-**Why Animations Rarely Seen**: Dashboard loads extremely fast (<500ms) so loading state is barely visible. Animations work perfectly but only visible on slow connections or initial loads.
-
-**Impact**: Professional, polished loading experience with smooth animations when loading state is visible.
+**Goal**: Redesign subscription management with Grok-inspired interface for clearer plan comparison and upgrade flows.
 
 ---
 
 ### Dashboard UI Polish ✅ (2026-02-07)
 
-**Goal**: Remove visual clutter from dashboard interface.
-
-**Work Completed**:
-1. **Manage Subscription Button Border Removal** ✅
-   - Changed button variant from `outline` (black border) to `ghost` (borderless)
-   - Maintains hover effects and clickability
-   - Aligns with minimalist Apple/Stripe/Cursor UI aesthetic
-   - File: `components/layout/minimal-header.tsx:25`
+**Fix**: Changed "Manage Subscription" button from `outline` to `ghost` variant in `components/layout/minimal-header.tsx:25`.
 
 ---
 
 ### Orphaned UserSubscription Database Cleanup ✅ (2026-02-07)
 
-**Goal**: Fix dashboard loading failures caused by orphaned UserSubscription records.
+**Problem**: Dashboard failing with "Field user is required to return data, got `null` instead" due to 2 orphaned UserSubscription records.
 
-**Problem**: Dashboard failing to load with Prisma error "Inconsistent query result: Field user is required to return data, got `null` instead" when accessing `/api/user/subscription` endpoint.
-
-**Root Cause**: 2 orphaned UserSubscription records (user IDs: `user_38eUp39nFdtmBwywmNdHehPd6aX`, `user_2xntabt8XePuJ5tQEMPYT3wd6vC`) referenced deleted User records. When the API route tried to include the `user` relation, Prisma failed because it expected valid user data but found `null`.
-
-**Fixes Applied**:
-
-1. **API Route Fix** (`app/api/user/subscription/route.ts`):
-   - Removed unnecessary `include: { user: ... }` clause from GET handler (line 59-69)
-   - User data wasn't used in response anyway, so including it was redundant
-   - Prevents future failures when data integrity issues occur
-
-2. **Created Cleanup Script** (`scripts/fix-orphaned-subscriptions.ts`):
-   - Identifies UserSubscription records with missing User references
-   - Safely deletes orphaned records with detailed reporting
-   - Can be reused for future data integrity checks
-
-3. **Database Cleanup**:
-   - Deleted 2 orphaned PRO plan subscriptions
-   - Verified 1 valid subscription remains
-   - All subscription records now have valid user references
-
-**Files Modified**:
-- `app/api/user/subscription/route.ts` - Removed user relation include
-- Created: `scripts/fix-orphaned-subscriptions.ts` (~130 lines)
-
-**Verification**:
-- ✅ 2 orphaned subscriptions identified and deleted
-- ✅ 1 valid subscription verified
-- ✅ Dashboard loads without errors
-- ✅ API endpoint handles missing user relations gracefully
-
-**Impact**: Dashboard is now resilient to data integrity issues. Even if orphaned subscriptions exist in future, the API won't crash.
+**Fix**: Removed unnecessary `include: { user: ... }` from GET handler in `app/api/user/subscription/route.ts`. Created `scripts/fix-orphaned-subscriptions.ts` for cleanup. Deleted 2 orphaned records.
 
 ---
 
 ### Form 4 Preference Sync Fix ✅ (2026-02-07)
 
-**Goal**: Fix missed Form 4 email notifications and prevent future preference sync issues.
+**Problem**: 60 Form 4 filings completed but emails NOT sent. Two separate preference systems (User.preferences vs Ticker.preferences) with no sync. Tickers created with `form4: false` default, ignoring user's `form4: true` preference.
 
-**Problem**: User hadn't received any notifications for 7+ days despite healthy pipeline. Investigation revealed 60 Form 4 filings completed but emails NOT sent.
-
-**Root Cause Discovered**:
-Two separate preference systems with no synchronization:
-- **User.preferences** (nested JSON): `preferences.notifications.filingTypes.insiderTrading.form4 = true`
-- **Ticker.preferences** (flat JSON): `preferences.form4 = false` (incorrectly defaulted)
-
-When tickers were created via POST `/api/user/tickers`, they received hardcoded `DEFAULT_PREFERENCES` with `form4: false`, completely ignoring the user's actual preference of `form4: true`.
-
-**Critical Finding**: `shouldProcessFiling()` in `summarize-cached-handler.ts` checks `Ticker.preferences`, not `User.preferences`, causing all Form 4 emails to be skipped.
-
-**Fixes Applied**:
-
-1. **Created `/lib/user/preference-sync.ts`** - Centralized preference conversion utilities:
-   - `convertUserPrefsToTickerPrefs()` - Converts nested User prefs to flat Ticker prefs
-   - `syncUserTickerPreferences()` - Syncs all ticker preferences for a user
-   - `getDefaultTickerPreferences()` - Centralized defaults (form4: true)
-
-2. **Updated `/app/api/user/tickers/route.ts`** - New tickers inherit user preferences:
-   - Reads user preferences when creating tickers
-   - Uses `convertUserPrefsToTickerPrefs()` to derive ticker preferences
-   - Falls back to centralized defaults from `getDefaultTickerPreferences()`
-
-3. **Updated `/app/api/user/tickers/[id]/route.ts`** - Uses centralized defaults
-
-4. **Updated `/lib/user/preference-service.ts`** - Auto-sync on preference updates:
-   - When user updates filing type preferences, automatically syncs to all tickers
-   - Ensures Ticker.preferences stays in sync with User.preferences
-
-5. **Updated `/lib/api/ticker-service.ts`** - Client-side fallback updated to `form4: true`
-
-6. **Synced existing data** - Fixed all 30 tickers across 3 users to have `form4: true`
-
-**Files Modified**:
-- Created: `lib/user/preference-sync.ts` (~140 lines)
-- Updated: `app/api/user/tickers/route.ts`, `app/api/user/tickers/[id]/route.ts`, `lib/user/preference-service.ts`, `lib/api/ticker-service.ts`
-
-**Verification**:
-- ✅ All 30 tickers now have `form4: true`
-- ✅ All 3 users have `form4: true` in their preferences
-- ✅ Build passes successfully
-- ✅ New tickers will inherit user preferences
-- ✅ User preference changes will auto-sync to all tickers
-- ✅ Database state verified with `scripts/verify-db-state.js`
-
-**Impact**: Form 4 notifications will now be sent correctly for future filings. The 60 missed Form 4 emails were a one-time data issue that has been resolved.
+**Fix**: Created `lib/user/preference-sync.ts` with centralized conversion utilities. Updated ticker creation (`app/api/user/tickers/route.ts`) to inherit user preferences. Auto-sync on preference updates via `lib/user/preference-service.ts`. Fixed all 30 tickers to `form4: true`.
 
 ---
 
 ### CLAUDE.md Agent Guidelines + Feedback Loop ✅ (2026-02-07)
 
-**Goal**: Create a feedback loop so future agents don't repeat past mistakes.
-
-**Problem Identified**: CLAUDE.md documented project architecture and commands but lacked agent-specific guidance. When agents made mistakes (wrong imports, guessed file paths, skipped tests), there was no mechanism to capture these learnings.
-
-**Fixes Applied**:
-
-1. **Added Agent Guidelines Section to CLAUDE.md** (lines 20-48):
-   - `### Common Mistakes to Avoid` - 6 actionable rules with HTML comment noting updates come via `/intentional-compact`
-   - `### Pattern References` - Table of exemplar files for API routes, services, database access, etc.
-   - `### Pre-Implementation Checklist` - Quick checks before writing code
-
-2. **Added Step 6 to intentional-compact.md** (lines 219-250):
-   - "Capture Lessons Learned for CLAUDE.md" step
-   - Reviews session for agent mistakes
-   - Updates CLAUDE.md Agent Guidelines when patterns emerge
-   - Reports what was captured
-
-3. **Updated Common Failure Modes** (lines 322-323):
-   - Added `6. Skipping Step 6` - Reminder to update CLAUDE.md
-   - Added `7. Vague guideline entries` - Entries must be actionable
-
-**Files Modified**:
-- `CLAUDE.md` - Added Agent Guidelines section (~30 lines)
-- `.claude/commands/intentional-compact.md` - Added Step 6 + failure modes (~35 lines)
-
-**Verification**:
-- ✅ CLAUDE.md now has Agent Guidelines section
-- ✅ intentional-compact.md has Step 6 for lessons learned
-- ✅ Feedback loop documented: mistake → /intentional-compact → CLAUDE.md update → future agents
-
-**Impact**: Future agents will read Agent Guidelines before implementation and avoid documented mistakes.
+Added Agent Guidelines section to CLAUDE.md (Common Mistakes, Pattern References, Pre-Implementation Checklist) and Step 6 to `/intentional-compact` for lessons learned capture.
 
 ---
 
 ### Unified Subscription Tiers + Billing Downgrade Fix ✅ (2026-01-28)
 
-**Issue 1**: 405 PUT errors when trying to downgrade from MAX plan on billing page.
+**Issues**: 405 PUT errors on billing downgrade; Prisma enum mismatch between `SubscriptionTier` and `PlanType`.
 
-**Root Cause**: `/api/user/subscription` route only had GET and POST handlers - missing PUT handler for plan changes and cancellation toggles.
-
-**Issue 2**: Prisma enum mismatch between `SubscriptionTier` (FREE/PROFESSIONAL/ENTERPRISE/INSTITUTION/HOBBY/PRO) and `PlanType` (FREE/PRO/MAX).
-
-**Root Cause**: Two different enums required mapping function `mapPlanToSubscriptionTier()` to convert between them, causing type complexity.
-
-**Fixes Applied**:
-
-1. **Added PUT Handler** (`app/api/user/subscription/route.ts`):
-   - Cancellation toggle: Updates `cancelAtPeriodEnd` in both Stripe and database
-   - Downgrade to FREE: Cancels Stripe subscription at period end
-   - Downgrade between paid plans (MAX→PRO): Updates Stripe subscription with proration
-   - Upgrades: Returns 400 with `action: 'checkout'` to redirect to Stripe checkout
-
-2. **Enhanced Billing Page** (`app/dashboard/billing/page.tsx`):
-   - For upgrades: Direct POST to create checkout session
-   - For downgrades: Use PUT to update subscription
-   - Shows success toast messages on plan changes
-   - Handles `action: 'checkout'` response from API
-
-3. **Unified Subscription Enums** (`prisma/schema.prisma`):
-   - Changed `SubscriptionTier` from `FREE/PROFESSIONAL/ENTERPRISE/INSTITUTION/HOBBY/PRO` to `FREE/PRO/MAX`
-   - Now matches `PlanType` enum exactly - no mapping needed
-   - Removed `mapPlanToSubscriptionTier()` function
-
-4. **Data Migration** (`scripts/migrate-to-unified-tiers.ts`):
-   - Migrated HOBBY→FREE (1 user)
-   - Would migrate INSTITUTION/PROFESSIONAL/ENTERPRISE→PRO (none found)
-   - Final distribution: 2 FREE users, 1 PRO user
-
-5. **Updated Tier Normalization** (`lib/cron/tier-eligibility.ts`):
-   - Maps PRO/MAX → PRO processing tier (5-minute frequency)
-   - Maps FREE → HOBBY processing tier (120-minute frequency)
-   - Maintains backwards compatibility with legacy tier names
-
-**Files Modified**:
-- `app/api/user/subscription/route.ts` - Added PUT handler, removed mapping function
-- `app/dashboard/billing/page.tsx` - Enhanced plan change logic
-- `prisma/schema.prisma` - Unified `SubscriptionTier` enum to FREE/PRO/MAX
-- `lib/cron/tier-eligibility.ts` - Updated normalization with new tiers
-- `scripts/migrate-to-unified-tiers.ts` - Created data migration script
-
-**Verification**:
-- ✅ Prisma client generated successfully
-- ✅ No TypeScript errors on subscription routes
-- ✅ Data migration completed (1 HOBBY→FREE user)
-- ✅ Lint passes without tier-related errors
-
-**Benefits**:
-- **Type Safety**: No more mapping errors between enums
-- **Simplicity**: Single source of truth for subscription tiers
-- **Consistency**: Stripe plans and database tiers use identical values
-- **Backwards Compatibility**: Legacy tier names still work through normalization
+**Fixes**:
+- Added PUT handler to `app/api/user/subscription/route.ts` (cancellation, downgrade, upgrade redirect)
+- Unified `SubscriptionTier` enum to `FREE/PRO/MAX` in `prisma/schema.prisma`
+- Created `scripts/migrate-to-unified-tiers.ts` - migrated HOBBY->FREE
+- Updated `lib/cron/tier-eligibility.ts` normalization
 
 ---
 
 ### Pipeline Stall Recovery + Throughput Optimization ✅ (2026-01-28)
 
-**Issue**: Pipeline stalled for 12+ hours (731 minutes since last completion) with 799 pending jobs and 0 processing. After initial recovery, throughput was only 12 jobs/hour (73 hours to clear backlog).
+**Issue**: Pipeline stalled 12+ hours, 799 pending jobs, throughput only 12 jobs/hour.
 
-**Root Causes Identified**:
+**Root Causes**: `vercel.json` invalid JSON (trailing commas), Cloudflare Worker crons stopped, CRON_SECRET sync issue, low summarize batch frequency.
 
-1. **vercel.json Invalid JSON**: Trailing commas on lines 32 and 122 made the file invalid JSON
-   - Line 32: After `email/welcome/route.ts` config block
-   - Line 122: After last item in `rewrites` array
-   - Impact: Could cause Vercel deployment/configuration failures
-
-2. **Cloudflare Worker Crons Not Firing**: Worker crons had stopped executing
-   - `cronExecution.lastExecution: null` in health endpoint
-   - `cronExecution.gapsDetected: 1`
-   - Resolution: Redeployed worker with `wrangler deploy`
-
-3. **CRON_SECRET Sync**: Re-synced 80-character secret to ensure Cloudflare and Vercel match
-
-4. **Low Summarize Throughput**: `ASYNC_SUMMARIZE_CACHED` batch size = 1 (intentional due to 30-270s AI processing time), but only triggered every 5 minutes = 12 jobs/hour max
-
-**Fixes Applied**:
-
-1. **Fixed vercel.json** - Removed trailing commas (lines 32, 122)
-2. **Redeployed Cloudflare Worker** - Restored cron schedule execution
-3. **Synced CRON_SECRET** - Used `wrangler secret put` to update Cloudflare Worker
-4. **Added Dedicated Summarize Cron** - New */3 cron for summarize-only processing
-   - Replaced */10 interval Slack summary (less critical) with */3 summarize-only
-   - New cron schedule: `*/3, */5, */15, daily` (4 crons, under Cloudflare 5-limit)
-   - Created `handleSummarizeOnly()` handler in index.js
-5. **Manual Backlog Processing** - Triggered 50+ manual summarize batches
-
-**Throughput Improvement**:
-- Before: 12 summarize jobs/hour (only from */5 pipeline)
-- After: ~32 summarize jobs/hour (*/3 summarize-only + */5 pipeline)
-- Effective: 130+ completions/hour observed
-
-**Recovery Results**:
-- Status: CRITICAL → HEALTHY
-- minutesSinceLastCompletion: 731 → 0
-- completedLast1h: 0 → 130+
-- Backlog: 880 → 719 (clearing at ~130/hour)
-- cronExecution.gapsDetected: 1 → 0
-
-**Files Modified**:
-- `vercel.json` - Fixed invalid JSON (trailing commas)
-- `cloudflare-cron/wrangler.toml` - Added */3 summarize cron, removed */10 Slack summary
-- `cloudflare-cron/index.js` - Added `handleSummarizeOnly()` handler
-
-**Verification**:
-- ✅ HMAC authentication working (HTTP 202)
-- ✅ Cloudflare Worker deployed with optimized cron schedules
-- ✅ Jobs completing at 130+/hour (was 12/hour)
-- ✅ Pipeline status HEALTHY
+**Fixes**: Fixed vercel.json, redeployed CF Worker, synced secrets, added dedicated */3 summarize-only cron. Throughput improved from 12 to 130+ jobs/hour.
 
 ---
 
 ### Unsent Email Recovery ✅ (2026-01-27)
 
-**Issue**: 47 completed summaries had `sentToUser: false` - emails never delivered.
-
-**Investigation Findings**:
-- 756 summaries with null `processingStatus` are LEGACY records (already sent before status tracking added)
-- 47 COMPLETED summaries with `sentToUser: false` were the actual backlog
-- All 47 had identical `processingCompletedAt` timestamp (2026-01-02T08:16:56.190Z) - indicating bulk status update
-- Original creation dates: Nov 28 (23), Dec 15 (17), Dec 26 (5), Jan 1 (2)
-- Root cause: Bulk migration to COMPLETED status didn't trigger email delivery
-
-**Scripts Created**:
-- `scripts/investigate-unsent.ts` - Analyze unsent summaries metadata, model versions, date distribution
-- `scripts/resend-unsent-emails.ts` - Resend emails with tracking updates and delivery records
-
-**Results**:
-- ✅ 46 emails sent successfully
-- ⚠️ 1 skipped (orphaned ticker - user deleted the ticker)
-- ✅ Database updated: `sentToUser: true`, `totalEmailsSent` incremented
-- ✅ SummaryEmailDelivery records created for audit trail
-
-**Usage**: `npx tsx scripts/resend-unsent-emails.ts [--dry-run] [--limit=N]`
+47 completed summaries with `sentToUser: false` from bulk migration. Created `scripts/resend-unsent-emails.ts`. Sent 46 emails (1 skipped - orphaned ticker).
 
 ---
 
 ### TickerMonitoring Root Cause Fix ✅ (2026-01-27)
 
-**Issue**: SEC filing discovery silently skipping all tickers because TickerMonitoring table was empty.
+**Problem**: SEC filing discovery silently skipping all tickers - TickerMonitoring table empty.
 
-**Root Cause Discovered**:
-The 3-phase async pipeline (default since 2025-12-24) bypassed the code path that creates TickerMonitoring records:
-1. **Legacy pipeline** (`runSecFilingMonitoring()`) calls `getActiveTickersForMonitoring()` which **UPSERTS** TickerMonitoring records
-2. **3-phase pipeline** (`handleDiscovery()`) only called `checkForNewFilings()` which **READS** from TickerMonitoring
-3. `checkForNewFilings()` silently skips any ticker without a TickerMonitoring record (line 90-97 in sec-filing-service.ts)
-4. Result: Discovery phase found 0 filings because there were no TickerMonitoring records to check
+**Root Cause**: 3-phase async pipeline bypassed code path that creates TickerMonitoring records. `checkForNewFilings()` silently skips tickers without TickerMonitoring records.
 
-**Critical Code Path Analysis**:
-- `sec-filing-service.ts:90-97` - Silent skip: `if (!tickerMonitoring) { continue; }`
-- `sec-filing-service.ts:156-221` - `runSecFilingMonitoring()` calls `getActiveTickersForMonitoring()` (UPSERTS)
-- `ticker-monitoring.ts:31-168` - `getActiveTickersForMonitoring()` upserts via `upsertTickerMonitoringWithLock()`
-- `tier-aware/route.ts:155-157` - 3-phase became default on 2025-12-24
-
-**Fixes Applied**:
-
-1. **Discovery Handler Fix** (`lib/cron/handlers/discovery-handler.ts`):
-   - Added call to `getActiveTickersForMonitoring()` at start of discovery phase
-   - Ensures TickerMonitoring records are created BEFORE RSS checking
-   - Lines 244-254: New STEP 1 with logging
-
-2. **Health Endpoint Enhancement** (`app/api/health/pipeline/route.ts`):
-   - Added `tickerMonitoring` section to health response
-   - Detects empty TickerMonitoring table as CRITICAL status
-   - Reports: totalRecords, activeRecords, userTickersWithoutMonitoring, missingTickers
-
-3. **Database Cleanup** - Removed duplicate GOOG ticker (user already had GOOGL tracked)
-
-**Verification**:
-- ✅ 15/15 user tickers now have TickerMonitoring records
-- ✅ 15/15 user tickers have CikMapping records
-- ✅ Health endpoint reports HEALTHY status with tickerMonitoring metrics
-- ✅ TypeScript compilation passes for modified files
-
-**Files Modified**:
-- `lib/cron/handlers/discovery-handler.ts` - Added `getActiveTickersForMonitoring()` call at discovery start
-- `app/api/health/pipeline/route.ts` - Added TickerMonitoring health check section
-
-**Impact**: Pipeline will now correctly discover filings for all tracked tickers instead of silently skipping them all
+**Fix**: Added `getActiveTickersForMonitoring()` call to `lib/cron/handlers/discovery-handler.ts` at start of discovery phase. Added TickerMonitoring health check to `app/api/health/pipeline/route.ts`.
 
 ---
 
 ### GitHub Actions Minutes Optimization ✅ (2026-01-27)
 
-**Goal**: Reduce GitHub Actions usage to fit within GitHub Pro 3,000 minute limit.
-
-**Analysis**: 7 workflows consuming ~1,990 minutes/month (at 2,000 limit capacity)
-
-**Optimizations Applied**:
-1. **Watchdog frequency reduced**: `*/10` → `*/30` (saves ~480 min/month)
-   - Safe because Cloudflare Worker (Layer 1) and Auto-Recovery (Layer 2) are primary triggers
-   - GitHub watchdog is "last line of defense" for external alerting only
-2. **Path filters added to quality-gates.yml**: Skip docs/config-only changes (saves ~150 min/month)
-3. **Path filters added to pr-validation.yml**: Skip docs/config-only changes (saves ~120 min/month)
-
-**Files Modified**:
-- `.github/workflows/pipeline-heartbeat-watchdog.yml` - Changed cron from `*/10` to `*/30`
-- `.github/workflows/quality-gates.yml` - Added path filters for code-only triggers
-- `.github/workflows/pr-validation.yml` - Added path filters for code-only triggers
-
-**Estimated Savings**: ~750 minutes/month → ~1,240 min/month usage (well within 3,000 Pro limit)
+Reduced GitHub Actions usage: Watchdog frequency `*/10` -> `*/30`, added path filters to quality-gates.yml and pr-validation.yml. Savings: ~750 min/month.
 
 ---
 
 ### Pipeline Resilience Zero-Intervention ✅ (2026-01-26)
 
-**PR**: [#340](https://github.com/wilfred-py/tldrsec-ai/pull/340) - Merged to main
+**PR**: [#340](https://github.com/wilfred-py/tldrsec-ai/pull/340)
 
-**Goal**: Eliminate human intervention requirements for pipeline recovery by addressing three root causes of manual intervention.
-
-**Implementation**:
-
-1. **Defensive CRON_SECRET Sanitization**:
-   - Created `lib/cron/secret-sanitization.ts` with automatic `.trim()` to prevent HMAC auth failures
-   - Updated `cloudflare-cron/index.js` (v2.7.0) to sanitize all CRON_SECRET usages
-   - Prevents recurring 13+ hour pipeline stalls from trailing `\n` characters
-
-2. **Faster Orphan Detection**:
-   - Removed 5% sampling limit from `app/api/health/pipeline/route.ts`
-   - Orphan detection now runs on every request (<15 second detection time)
-   - Enables immediate recovery of orphaned filings
-
-3. **External Heartbeat Watchdog**:
-   - Created `.github/workflows/pipeline-heartbeat-watchdog.yml` - runs every 10 minutes
-   - Monitors `/api/health/pipeline` endpoint independently
-   - Sends email alerts via Resend API if pipeline stalls (15+ min without completion)
-   - Last line of defense when all internal layers fail
-
-**Verification**:
-- ✅ 30/30 tests passing (18 unit + 12 integration)
-- ✅ Multi-perspective review: 6/6 approved (Product, Developer, QE, Security, DevOps, UX)
-- ✅ Cloudflare Worker secret sync completed
-- ✅ HMAC authentication verified (HTTP 202)
-- ✅ External watchdog test alert sent successfully
-
-**Files**:
-- Created: `lib/cron/secret-sanitization.ts`, `lib/monitoring/heartbeat-alert.ts`, `.github/workflows/pipeline-heartbeat-watchdog.yml`
-- Modified: `cloudflare-cron/index.js`, `app/api/health/pipeline/route.ts`
-- Tests: `__tests__/unit/cron-secret-sanitization.test.ts`, `__tests__/integration/heartbeat-watchdog.test.ts`
-
-**Impact**: Zero manual intervention required for pipeline recovery, MTTR reduced from hours to minutes
-
-### Phase 4: Pipeline Stall Recovery & Bug Fixes (2026-01-26) ✅
-**Issue**: Pipeline stalled for 5.5+ hours with 290 pending jobs, 0 processing, no completions.
-
-**Root Causes Discovered**:
-1. **Auto-recover cascade failure**: Health endpoint returns HTTP 503 for CRITICAL status, but auto-recover checked `response.ok` which is false for 503, causing it to throw an error instead of proceeding with recovery - exactly when recovery is needed most!
-2. **OrphanedFilingDetector using wrong table**: Code queried `SecFiling.processed` field which doesn't exist (the `processed` field is on `RssFilingCheck` table), causing Prisma errors.
-3. **Cloudflare Worker stopped executing**: Unknown reason caused all cron triggers to stop for 38+ minutes.
-
-**Fixes Applied**:
-1. **Auto-recover HTTP 503 handling**: Updated `getPipelineHealth()` in `app/api/cron/auto-recover/route.ts` to parse JSON body even for 503 responses (CRITICAL status), only failing on 500 (ERROR).
-2. **OrphanedFilingDetector table fix**: Updated `lib/cron/orphaned-filing-detector.ts` to query `rssFilingCheck` table instead of `secFiling`, and changed job type to `ASYNC_SUMMARIZE_CACHED`.
-3. **Cloudflare Worker redeploy**: Redeployed worker to restart cron triggers.
-
-**Files Modified**:
-- `app/api/cron/auto-recover/route.ts` - Handle HTTP 503 from health endpoint
-- `lib/cron/orphaned-filing-detector.ts` - Use correct table (RssFilingCheck)
-
-**Recovery Results**:
-- Status: CRITICAL → DEGRADED
-- completedLast1h: 0 → 25+
-- minutesSinceLastCompletion: 335 → 2
-- Cron execution restored (every 5 minutes)
-- Backlog being processed (276 remaining)
+Created: `lib/cron/secret-sanitization.ts` (CRON_SECRET auto-trim), removed 5% sampling limit from orphan detection, `.github/workflows/pipeline-heartbeat-watchdog.yml` (external monitoring). 30/30 tests passing.
 
 ---
 
-### BAC 424B2 Filtering Breach Investigation & Documentation ✅ (2026-01-25)
+### Stripe Webhook planType Sync Fix ✅ (2026-01-26)
 
-**Issue**: User received BAC 424B2 email at 4:01 PM AEST despite prospectus filtering being deployed.
+**PR**: [#339](https://github.com/wilfred-py/tldrsec-ai/pull/339)
 
-**Root Cause Discovered**:
-1. **Immediate**: BAC ticker had NULL preferences (no defaults set)
-2. **Systemic**: Async pipeline handlers (`summarize-cached-handler.ts`) bypass filtering - don't re-check preferences at summarize stage
-3. **Timing**: Jobs queued before deployment (Jan 21) processed after deployment (Jan 25) without preference validation
+**Fix**: Stripe webhook was not syncing `planType` to User.subscriptionTier. Also improved checkout UX flow.
 
-**Critical Discovery**: **27 out of 31 tickers had NULL preferences** (87% of all tickers!)
+---
 
-**Documentation Created**:
-- `docs/investigation/2026-01-25-bac-424b2-filtering-breach.md` (351 lines) - Full technical investigation
-- `docs/investigation/2026-01-25-filtering-breach-SUMMARY.md` (325 lines) - Executive summary
-- `DEPLOYMENT_NEXT_STEPS.md` (299 lines) - PR #335 deployment procedures
+### Pipeline Stall Recovery & Bug Fixes ✅ (2026-01-26)
 
-**Impact**: 15 BAC 424B2 emails sent (13 after filtering deployed), affected 3 users, widespread vulnerability across 87% of tickers
+**Root Causes**: Auto-recover threw error on HTTP 503 (CRITICAL status) instead of proceeding with recovery; OrphanedFilingDetector queried wrong table.
 
-**Immediate Fixes Applied** (not in this PR - already in production):
-1. ✅ Set BAC ticker preferences to disable 424B2
-2. ✅ Updated all 27 vulnerable tickers with default preferences
-3. ✅ Result: All 31 tickers now have explicit preferences
+**Fixes**: `app/api/cron/auto-recover/route.ts` handles 503 now; `lib/cron/orphaned-filing-detector.ts` queries correct table.
 
-**Systemic Fix Needed** (documented for next deployment):
-- Add preference filtering to `lib/cron/handlers/summarize-cached-handler.ts`
-- Add defense-in-depth validation at ALL async pipeline stages
+---
+
+### BAC 424B2 Filtering Breach Investigation ✅ (2026-01-25)
+
+User received BAC 424B2 email despite filtering. Root cause: BAC ticker had NULL preferences, 27/31 tickers had NULL preferences (87%). Fixed all 31 tickers with explicit preferences. Documented in `docs/investigation/`.
+
+---
+
+### Prospectus Filing Type Preferences ✅ (2026-01-23)
+
+**PR**: [#335](https://github.com/wilfred-py/tldrsec-ai/pull/335)
+
+**Goal**: Add prospectus filing type preferences to reduce email volume. Users can now filter out 424B2 and similar filings.
 
 ---
 
 ### Stripe Dashboard Integration Fixes ✅ (2026-01-25)
 
-**Goal**: Fix Stripe checkout flow from dashboard upgrade CTA buttons.
-
-### Summary
-Fixed multiple issues preventing Stripe checkout from dashboard: client/server module split, Price ID lookup, database enum migration, and Clerk user sync.
-
-### Stripe Client/Server Module Split ✅
-**Issue**: Browser console showing "Missing Stripe environment variables" warnings on every page load.
-
-**Root Cause**: `lib/stripe.ts` was imported by client components (`dashboard-client.tsx`, `upgrade-cta-section.tsx`, etc.) but environment variables without `NEXT_PUBLIC_` prefix are only available server-side.
-
-**Fix**: Split `lib/stripe.ts` into separate modules:
-- `lib/stripe/plans.ts` - Client-safe constants (SUBSCRIPTION_PLANS, types, utility functions)
-- `lib/stripe/index.ts` - Server-only Stripe client (env var checks only run server-side)
-
-**Files Created**:
-- `lib/stripe/plans.ts` (~170 lines)
-- `lib/stripe/index.ts` (~270 lines)
-
-**Files Modified** (updated imports to use `@/lib/stripe/plans`):
-- `components/dashboard/upgrade-cta-section.tsx`
-- `components/dashboard/dashboard-client.tsx`
-- `components/landing/sections/pricing-section.tsx`
-- `components/landing/sections-v2/pricing-section-v2.tsx`
-- `components/billing/subscription-plans.tsx`
-- `app/dashboard/billing/page.tsx`
-
-**Files Renamed**: `lib/stripe.ts` → `lib/stripe.ts.bak`
-
-### Subscription API Price ID Lookup Fix ✅
-**Issue**: POST `/api/user/subscription` returning 503 "Stripe price ID not configured for PRO monthly"
-
-**Root Cause**: API route was reading `plan.monthlyPriceId` from `SUBSCRIPTION_PLANS` which now returns `null` (client-safe version doesn't include env vars).
-
-**Fix**: Updated routes to use `getPriceIdForPlan()` function that reads directly from environment variables.
-
-**Files Modified**:
-- `app/api/user/subscription/route.ts` - Added `getPriceIdForPlan` import and usage
-- `app/api/checkout/direct/route.ts` - Same fix plus null check for stripe client
-
-### Database PlanType Enum Migration ✅
-**Issue**: Prisma upsert failing with `invalid input value for enum app."PlanType": "PRO"`
-
-**Root Cause**: Database had old enum values (BASIC, PROFESSIONAL, PREMIUM) but code uses new values (FREE, PRO, MAX).
-
-**Fix**:
-1. Added new enum values: `ALTER TYPE app."PlanType" ADD VALUE IF NOT EXISTS 'FREE/PRO/MAX'`
-2. Migrated existing records: `UPDATE app."UserSubscription" SET "planType" = 'FREE' WHERE "planType" = 'BASIC'` (etc.)
-3. Updated type cast in route.ts from `'BASIC' | 'PROFESSIONAL' | 'MAX'` to `'FREE' | 'PRO' | 'MAX'`
-
-### Clerk User Sync Script ✅
-**Issue**: "User not found in database" warnings for Clerk-authenticated users.
-
-**Root Cause**: User logged into Clerk but no corresponding record in local Prisma database.
-
-**Fix**: Created `scripts/sync-clerk-user.ts` to fetch user from Clerk API and create/update local database record.
-
-**Files Created**: `scripts/sync-clerk-user.ts` (~130 lines)
-
-**Usage**: `npx tsx scripts/sync-clerk-user.ts <clerk_user_id>` or `--email <email>`
-
-### Stripe Product Description Copy Update
-Updated Pro Monthly product description in Stripe Dashboard from feature list to benefit-focused copy:
-> "Real-time SEC filing intelligence. Stop finding out about material events after the market moves."
+Split `lib/stripe.ts` into `lib/stripe/plans.ts` (client-safe) + `lib/stripe/index.ts` (server-only). Fixed Price ID lookup with `getPriceIdForPlan()`. Migrated PlanType enum (BASIC/PROFESSIONAL/PREMIUM -> FREE/PRO/MAX). Created `scripts/sync-clerk-user.ts`.
 
 ---
 
@@ -719,9 +257,7 @@ For complete technical details of projects older than 30 days, see the weekly ar
 - **November 2025**: 4 weekly archives
 - **October 2025**: 2 weekly archives
 
-Recent highlights include SEC filing quality enhancements, pipeline resilience improvements, dashboard redesigns, and comprehensive auth/onboarding flows. All archived projects maintain full technical documentation including root causes, implementation details, files modified, and verification results.
-
 ---
 
-*Last Updated: 2026-02-10 (Pipeline job processing improvements: DLQ cleanup automation, retry pattern documentation, test suite fixes)*
+*Last Updated: 2026-02-12 (TrialService fix, Cloudflare cron consolidation)*
 *Completed projects older than 30 days are archived to .claude/history/ - See TIMELINE.md for complete historical context*

--- a/TIMELINE.md
+++ b/TIMELINE.md
@@ -13,21 +13,22 @@
 
 | Date | Project | Status |
 |------|---------|--------|
-| 2026-01-22 | SEC Filing Summary & Email Quality Enhancement (All 4 Phases) | 🔄 Active in PROGRESS.md |
-| 2026-01-21 | Cloudflare Build Fix - Onboarding Dynamic Rendering | 🔄 Active in PROGRESS.md |
-| 2026-01-19 | Onboarding Redirect Race Condition Fix | 🔄 Active in PROGRESS.md |
-| 2026-01-19 | Pipeline Recovery - Zombie Connection Pool Exhaustion | 🔄 Active in PROGRESS.md |
-| 2026-01-16 | Email Template Type Errors Fix | 🔄 Active in PROGRESS.md |
-| 2026-01-15 | SEC Summary Quality Phase 2 - Phase 4: Grokipedia Research | 🔄 Active in PROGRESS.md |
-| 2026-01-15 | 8-K Email Template Registry Fix | 🔄 Active in PROGRESS.md |
-| 2026-01-13 | Pipeline Recovery - Database Migration Fix | 🔄 Active in PROGRESS.md |
-| 2026-01-12 | Pipeline Stall Investigation - Database Connection Pool Fix | 🔄 Active in PROGRESS.md |
-| 2026-01-12 | GitHub Actions Workflow Updates | 🔄 Active in PROGRESS.md |
-| 2026-01-11 | Eliminate Manual Pipeline Intervention - Phases 5-8 | 🔄 Active in PROGRESS.md |
-| 2026-01-11 | clerkMiddleware API Fix | 🔄 Active in PROGRESS.md |
-| 2026-01-10 | Critical Job Queue Database Bug Fix | 🔄 Active in PROGRESS.md |
-| 2026-01-09 | Summary Generation Quality Improvement - Phase 5 | 🔄 Active in PROGRESS.md |
-| 2026-01-09 | Fix Orphaned Filings Pipeline | 🔄 Active in PROGRESS.md |
+| 2026-02-11 | FREE Plan to 7-Day Trial Migration (8 Phases) | ✅ Complete |
+| 2026-02-10 | Pipeline Job Processing Improvements (DLQ, Retry Docs, Tests) | ✅ Complete |
+| 2026-02-07 | Dashboard Loading Skeleton Enhancement | ✅ Complete |
+| 2026-02-07 | Dashboard UI Polish | ✅ Complete |
+| 2026-02-07 | Orphaned UserSubscription Database Cleanup | ✅ Complete |
+| 2026-02-07 | Form 4 Preference Sync Fix | ✅ Complete |
+| 2026-02-07 | CLAUDE.md Agent Guidelines + Feedback Loop | ✅ Complete |
+| 2026-01-28 | Unified Subscription Tiers + Billing Downgrade Fix | ✅ Complete |
+| 2026-01-28 | Pipeline Stall Recovery + Throughput Optimization | ✅ Complete |
+| 2026-01-27 | Unsent Email Recovery (46 emails resent) | ✅ Complete |
+| 2026-01-27 | TickerMonitoring Root Cause Fix | ✅ Complete |
+| 2026-01-27 | GitHub Actions Minutes Optimization | ✅ Complete |
+| 2026-01-26 | Pipeline Resilience Zero-Intervention (PR #340) | ✅ Complete |
+| 2026-01-26 | Pipeline Stall Recovery & Bug Fixes | ✅ Complete |
+| 2026-01-25 | BAC 424B2 Filtering Breach Investigation | ✅ Complete |
+| 2026-01-25 | Stripe Dashboard Integration Fixes | ✅ Complete |
 
 *These will be archived once they are older than 30 days AND PROGRESS.md exceeds 500 lines*
 
@@ -43,6 +44,6 @@
 
 ## Archive Statistics
 - **Total Archived Projects**: 0
-- **Current PROGRESS.md Lines**: 335
-- **Last Sync**: 2026-01-22
+- **Current PROGRESS.md Lines**: 220
+- **Last Sync**: 2026-02-11
 - **Archive System**: ✅ ACTIVE

--- a/lib/auth/trial-service.ts
+++ b/lib/auth/trial-service.ts
@@ -25,8 +25,13 @@ export class TrialService {
   static async checkTrialStatus(userId: string): Promise<TrialStatus> {
     const prisma = getPrismaClient();
 
-    const user = await prisma.user.findUnique({
-      where: { id: userId },
+    const user = await prisma.user.findFirst({
+      where: {
+        OR: [
+          { id: userId },
+          { authProviderId: userId },
+        ],
+      },
       select: {
         subscriptionTier: true,
         trialEndsAt: true,
@@ -36,7 +41,14 @@ export class TrialService {
     });
 
     if (!user) {
-      throw new Error('User not found');
+      // User exists in Clerk but not yet in DB (created on first tickers fetch).
+      // Return active/grandfathered so the subscription endpoint doesn't 500.
+      return {
+        isActive: true,
+        daysRemaining: Infinity,
+        trialEndsAt: null,
+        isGrandfathered: true,
+      };
     }
 
     // Paid users (PRO/MAX) - always active


### PR DESCRIPTION
## Summary
Fixes `/api/user/subscription` 500 errors caused by incorrect user lookup in TrialService. The service was looking up users by database `id`, but Clerk `userId` is stored in the `authProviderId` field.

## Changes
- Changed `findUnique({ where: { id } })` to `findFirst({ where: { OR: [{ id }, { authProviderId }] } })` in `lib/auth/trial-service.ts`
- Added graceful fallback returning active/grandfathered status when user not yet in database
- Updated CLAUDE.md with Common Mistake #9 documenting this pattern for future agents
- Updated PROGRESS.md, TIMELINE.md, and .claude/history/TIMELINE.md with recent project completions

## Root Cause
TrialService.checkTrialStatus() was called with Clerk's userId (e.g., `user_2abc...`) but was querying by the database's auto-increment `id` field. Clerk userId is stored in the `authProviderId` column, not `id`.

## Solution Pattern
Follows the existing pattern from `app/api/user/tickers/route.ts` which correctly handles this by checking both fields.

## Test Plan
- [x] Build passes
- [x] No TypeScript errors
- [x] Pattern documented in CLAUDE.md to prevent recurrence
- [x] Graceful handling when user doesn't exist yet in DB

## Related Issues
Prevents 500 errors when authenticated users access subscription endpoint before their first ticker fetch (which creates the User record).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>