### PR TITLE
Hide nav links on sign-in and sign-up pages

### DIFF
--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -21,12 +21,14 @@ export function Navigation() {
             </Link>
           </div>
 
-          <nav className="hidden md:flex items-center space-x-1">
-            <NavLink href="#features">Features</NavLink>
-            <NavLink href="#pricing">Pricing</NavLink>
-            <NavLink href="/changelog">Changelog</NavLink>
-            <NavLink href="/contact">Contact</NavLink>
-          </nav>
+          {!isAuthPage && (
+            <nav className="hidden md:flex items-center space-x-1">
+              <NavLink href="#features">Features</NavLink>
+              <NavLink href="#pricing">Pricing</NavLink>
+              <NavLink href="/changelog">Changelog</NavLink>
+              <NavLink href="/contact">Contact</NavLink>
+            </nav>
+          )}
 
           <div className="flex items-center">
             {!isLoading && !isAuthPage && (


### PR DESCRIPTION
## Summary
Conditionally hides navigation links (Features, Pricing, Changelog, Contact) on authentication pages (sign-in and sign-up) to provide a cleaner, distraction-free auth experience.

## Changes
- Wrapped the `<nav>` element in `components/navigation.tsx` with an `!isAuthPage` conditional check
- Nav links are hidden on auth pages while the logo and auth buttons remain visible

## Test Plan
- [ ] Sign-in page shows logo but no nav links
- [ ] Sign-up page shows logo but no nav links
- [ ] All other pages (landing, dashboard, etc.) still show nav links
- [ ] Mobile responsive menu unaffected

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>