### PR TITLE
Update free tier pricing card to trial messaging

### DIFF
--- a/components/landing/sections/pricing-section.tsx
+++ b/components/landing/sections/pricing-section.tsx
@@ -51,7 +51,7 @@ function PricingCard({
 
   const ctaText =
     planKey === 'FREE'
-      ? 'Start Free'
+      ? 'Start Free Trial'
       : planKey === 'PRO'
         ? 'Start Pro Trial'
         : 'Start Max';
@@ -118,9 +118,6 @@ function PricingCard({
           )}
           {billingInterval === 'monthly' && planKey !== 'FREE' && (
             <p className="text-sm text-slate-500 mt-1">Billed monthly</p>
-          )}
-          {planKey === 'FREE' && (
-            <p className="text-sm text-slate-500 mt-1">Free forever</p>
           )}
         </div>
 


### PR DESCRIPTION
## Summary
Updates the free tier pricing card on the landing page to better communicate the trial-based model:
- Changed CTA button from "Start Free" to "Start Free Trial"
- Removed redundant "Free forever" subtitle text

## Changes
- `components/landing/sections/pricing-section.tsx`: Updated CTA text and removed redundant copy

## Test Plan
- [ ] Landing page renders correctly with updated pricing card
- [ ] Free tier CTA reads "Start Free Trial"
- [ ] "Free forever" text no longer appears
- [ ] Other tier cards (Pro, Max) unaffected

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>