### PR TITLE
Improve summary quality: Form 144 ownership, Form 4 schema, email templates

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,42 +1,54 @@
 # Project Progress
 
-**Date**: 2026-03-05
-**Branch**: worktree-onboarding
-**Status**: Onboarding & Tutorial Flow Overhaul - in progress (Tasks 1-7 complete, polishing tutorial conditions)
+**Date**: 2026-03-10
+**Branch**: worktree-summary-enhancements
+**Status**: Summary quality enhancements - Form 144 ownership, Form 4 schema, email template visual fixes
 
 ---
 
 ## Current Session
 
+### Summary Quality Enhancements: Form 144 & Email Templates (2026-03-04 → in progress)
+
+**Branch**: `worktree-summary-enhancements` | **Plan**: `docs/plans/2026-03-04-fix-form4-classification-data-flow.md`
+
+**Goal**: Fix Form 4 classification data flow, Form 144 ownership data gaps, and polish email template visuals across all form types.
+
+**Completed Work**:
+
+**Form 4 AI Schema** ✅ - Made `sharesOwnedFollowing` required in Form 4 transaction items in `unified-prompts.ts`. AI now always extracts post-transaction beneficial ownership.
+
+**Form 144 Ownership Data Extraction** ✅ - Multi-layer fix:
+- Raised `extractRemainingHoldings` regex cap from 1B→100B (Tesla has 3.7B outstanding)
+- Raised `extractShares` cap from 100M→10B in `form144-data-extractor.ts`
+- Added `noOfUnitsOutstanding` and `aggregateMarketValue` XML extraction to all 3 Form 144 parsers (`form144Parser.ts`, `form144.ts`, `form144Service.ts`)
+- Added `sharesOutstanding` as required field in Form 144 AI schema
+- Added `extractSharesOutstanding()` text-based fallback in data extractor
+- Added `sharesOutstanding`/`aggregateMarketValue` to `Form144ParsedContent` interface
+
+**Form 144 Email Template** ✅ - `form144-minimalist-template.tsx`:
+- Ownership Impact only shows when insider's actual `remainingHoldings` is available (numeric)
+- Removed misleading Case 2 that showed issuer-level `sharesOutstanding` as "ownership impact" — this is company total class shares, not the insider's position
+- Filtered out non-numeric `remainingHoldings` values (e.g., "Not disclosed") from Shares card
+- When remaining holdings IS available: shows before→↓→after with percentage (matches Form 4 visual)
+
+**8-K Email Template** ✅ - `8k-minimalist-template.tsx`:
+- Key Highlights bullets changed from inline `<span>` to two-column `<table>` layout
+- Wrapped text now aligns with text content, not the bullet character
+
+**Verification**: All E2E tests passing (5/5 - TSLA, VRT, COIN, KO, NVDA). 79/79 Form 4 classification tests pass. 40/40 Form 4 AI schema regression tests pass.
+
+**Files Modified**: `lib/ai/prompts/unified-prompts.ts`, `lib/email/form144-data-extractor.ts`, `types/sec/form144.ts`, `services/filings/parsers/form144Parser.ts`, `services/filings/form144.ts`, `services/form144Service.ts`, `components/ui/email/templates/form144-minimalist-template.tsx`, `components/ui/email/templates/8k-minimalist-template.tsx`, `components/ui/email/templates/form4-minimalist-template.tsx`
+
+**Files Created**: `__tests__/regression/form4-ai-schema-classification.test.ts`, `docs/plans/2026-03-04-fix-form4-classification-data-flow.md`
+
+---
+
+## Other Active Worktree
+
 ### Onboarding & Tutorial Flow Overhaul (2026-03-02 → in progress)
 
-**Branch**: `worktree-onboarding` | **Plan**: `docs/plans/2026-03-02-onboarding-tutorial-flow-overhaul.md`
-
-**Goal**: Polish the onboarding → tutorial experience with unskippable flow, company logos, animated transitions, confetti, and cached summary delivery.
-
-**Completed Tasks**:
-
-**Task 1: Update Onboarding Flow** ✅ - Changed ticker limit from 5 to 3 (FREE tier), added Clearbit company logos with letter-avatar fallback (`components/ui/company-logo.tsx`), enhanced search with dual sector + API-backed results, made onboarding unskippable.
-
-**Task 2: Brand-Colored Progress Bar** ✅ - Added `variant="brand"` to `components/ui/progress.tsx` with gradient `from-[#0079F2] to-[#8B5CF6]`, defined in `app/globals.css`.
-
-**Task 3: Animated Transition Screen** ✅ - Created `components/onboarding/onboarding-transition.tsx` with Framer Motion text cycling (completion-based, ~2s minimum), replaces toast on success.
-
-**Task 4: Make Tutorial Unskippable** ✅ - Removed skip button and X close from `tutorial-guide.tsx`, removed `hasSeenTutorial` localStorage, kept `tutorialProgress` localStorage for step resume on refresh, tutorial only dismisses after completing all steps.
-
-**Task 5: Cached Summary Delivery** ✅ - Created `lib/onboarding/cached-summary-delivery.ts` (composite ranking: type weight 40% + quality 30% + recency 30%), `app/api/onboarding/deliver-summaries/route.ts` (POST endpoint). Finds top 2 summaries per ticker across all users, sends as digest email. Edge cases handled: no email, zero summaries, email failure.
-
-**Task 6: Confetti Enhancement** ✅ - Increased particles to 200, dismiss delay to 5s in `components/ui/confetti.tsx`.
-
-**Task 7: Wire Everything Together** ✅ - End-to-end flow: onboarding → transition screen → dashboard → tutorial → confetti → cached summaries + welcome email.
-
-**Current polish**:
-- Tutorial show condition uses `tutorialCompletedAt` (not ticker count) - confirmed correct
-- Made step 1 ticker limit dynamic via `tickerLimit` prop (FREE=3, PRO=25, MAX=unlimited)
-
-**Files Modified**: `app/(auth)/onboarding/onboarding-client.tsx`, `components/onboarding/tutorial-guide.tsx`, `components/onboarding/actions.ts`, `components/dashboard/dashboard-client.tsx`, `components/dashboard/tickers-table/columns.tsx`, `components/ui/progress.tsx`, `components/ui/confetti.tsx`, `app/globals.css`, `__tests__/components/dashboard/dashboard-inline-integration.test.tsx`
-
-**Files Created**: `components/ui/company-logo.tsx`, `components/onboarding/onboarding-transition.tsx`, `lib/onboarding/cached-summary-delivery.ts`, `app/api/onboarding/deliver-summaries/route.ts`, `docs/plans/2026-03-02-onboarding-tutorial-flow-overhaul.md`
+**Branch**: `worktree-onboarding` | Tasks 1-7 complete, polishing tutorial conditions. See onboarding worktree for full details.
 
 ---
 
@@ -138,5 +150,5 @@ For complete technical details of projects older than 30 days, see the weekly ar
 
 ---
 
-*Last Updated: 2026-03-05 (Onboarding tutorial flow overhaul - worktree in progress)*
+*Last Updated: 2026-03-10 (Summary quality enhancements - Form 144 ownership, email template fixes)*
 *Completed projects older than 30 days are archived to .claude/history/ - See TIMELINE.md for complete historical context*

--- a/TIMELINE.md
+++ b/TIMELINE.md
@@ -13,6 +13,7 @@
 
 | Date | Project | Status |
 |------|---------|--------|
+| 2026-03-10 | Summary Quality Enhancements: Form 144 Ownership & Email Templates (worktree) | 🔄 In Progress |
 | 2026-03-05 | Onboarding & Tutorial Flow Overhaul (worktree) | 🔄 In Progress |
 | 2026-03-02 | Pipeline Throughput & Worker Cleanup (PR #357) | ✅ Complete |
 | 2026-02-25 | Update Free Tier Pricing Card CTA (PR #355) | ✅ Complete |
@@ -95,6 +96,6 @@
 ## Archive Statistics
 - **Total Archived Projects**: 25
 - **Current PROGRESS.md Lines**: 142
-- **Last Sync**: 2026-03-05
+- **Last Sync**: 2026-03-10
 - **Last Archive Update**: 2026-03-05
 - **Archive System**: ✅ ACTIVE

--- a/__tests__/email/form4-transaction-classification.test.ts
+++ b/__tests__/email/form4-transaction-classification.test.ts
@@ -252,7 +252,7 @@ describe('Form 4 Transaction Classification - All 21 SEC Codes', () => {
 
     it('should return teal config for exercise type', () => {
       const config = getTransactionTypeConfig('exercise');
-      expect(config.label).toBe('Derivative Activity');
+      expect(config.label).toBe('Exercised Options');
       expect(config.bgColor).toBe('#F0FDFA');
     });
 

--- a/__tests__/regression/form4-ai-schema-classification.test.ts
+++ b/__tests__/regression/form4-ai-schema-classification.test.ts
@@ -1,0 +1,545 @@
+/**
+ * Form 4 AI Schema → Template Classification Regression Tests
+ *
+ * These tests verify that data shaped like ACTUAL AI output (from unified-prompts.ts)
+ * classifies correctly in the email template.
+ *
+ * Key difference from summary-quality-2026-02-18.test.ts: those tests provide `code`
+ * explicitly with template-native field names. These tests use AI-schema field names
+ * (e.g., `price` instead of `pricePerShare`) to catch data flow mismatches.
+ */
+
+import {
+  aggregateTransactionsByType,
+} from '../../components/ui/email/templates/form4-minimalist-template';
+import { parseStringTransaction, parseResponse } from '../../lib/ai/parsers/response-parser';
+import { generateFilingPrompt, FORM_SCHEMAS } from '../../lib/ai/prompts/unified-prompts';
+
+// Helper: create transaction shaped like AI output (unified-prompts.ts Form 4 schema)
+function aiTx(overrides: {
+  code: string;
+  type: string;
+  shares: string;
+  price: string;          // AI field name (NOT pricePerShare)
+  date?: string;
+  acquisitionDisposition?: string;
+}) {
+  return overrides;
+}
+
+describe('Form 4: AI Schema → Template Classification', () => {
+  describe('code field enables correct classification', () => {
+    it('should classify code A + type "Award/Grant" as award (not other)', () => {
+      const transactions = [
+        aiTx({ code: 'A', type: 'Award/Grant', shares: '2,500', price: '$0', acquisitionDisposition: 'A' }),
+      ];
+      const result = aggregateTransactionsByType(transactions);
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('award');
+    });
+
+    it('should classify code S + type "Sale" as sale', () => {
+      const transactions = [
+        aiTx({ code: 'S', type: 'Sale', shares: '10,000', price: '$150.50', acquisitionDisposition: 'D' }),
+      ];
+      const result = aggregateTransactionsByType(transactions);
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('sale');
+    });
+
+    it('should classify code G + type "Gift" as gift', () => {
+      const transactions = [
+        aiTx({ code: 'G', type: 'Gift', shares: '5,000', price: '$0', acquisitionDisposition: 'D' }),
+      ];
+      const result = aggregateTransactionsByType(transactions);
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('gift');
+    });
+
+    it('should classify code P + type "Purchase" as purchase', () => {
+      const transactions = [
+        aiTx({ code: 'P', type: 'Purchase', shares: '1,000', price: '$200', acquisitionDisposition: 'A' }),
+      ];
+      const result = aggregateTransactionsByType(transactions);
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('purchase');
+    });
+
+    it('should classify code M + type "Exercise" as exercise', () => {
+      const transactions = [
+        aiTx({ code: 'M', type: 'Exercise', shares: '5,000', price: '$25', acquisitionDisposition: 'A' }),
+      ];
+      const result = aggregateTransactionsByType(transactions);
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('exercise');
+    });
+  });
+
+  describe('price field maps to dollar values (not $0)', () => {
+    it('should compute correct totalValue from AI price field', () => {
+      const transactions = [
+        aiTx({ code: 'S', type: 'Sale', shares: '10,000', price: '$150', acquisitionDisposition: 'D' }),
+      ];
+      const result = aggregateTransactionsByType(transactions);
+      expect(result[0].totalValue).toBe(1500000); // 10000 * 150
+      expect(result[0].totalValue).not.toBe(0);
+    });
+
+    it('should show shares for $0 gift transactions (not misleading "$0")', () => {
+      const transactions = [
+        aiTx({ code: 'G', type: 'Gift', shares: '73,252', price: '$0', acquisitionDisposition: 'D' }),
+      ];
+      const result = aggregateTransactionsByType(transactions);
+      expect(result[0].type).toBe('gift');
+      expect(result[0].totalShares).toBe(73252);
+      expect(result[0].totalValue).toBe(0);
+    });
+  });
+
+  describe('backward compatibility: old summaryJSON with price field', () => {
+    it('should handle transaction with price (no pricePerShare) from old DB records', () => {
+      // Old summaryJSON stored price as "price", not "pricePerShare"
+      const oldFormatTx = { code: 'S', type: 'Sale', shares: '5,000', price: '$100' };
+      const result = aggregateTransactionsByType([oldFormatTx]);
+      expect(result[0].type).toBe('sale');
+      expect(result[0].totalValue).toBe(500000);
+    });
+  });
+
+  describe('type-only fallback (no code field)', () => {
+    it('should classify type "Award/Grant" as award when code is missing', () => {
+      const tx = { type: 'Award/Grant', shares: '2,500', price: '$0' };
+      const result = aggregateTransactionsByType([tx]);
+      expect(result[0].type).toBe('award');
+    });
+
+    it('should classify type "Sale" as sale when code is missing', () => {
+      const tx = { type: 'Sale', shares: '10,000', price: '$150' };
+      const result = aggregateTransactionsByType([tx]);
+      expect(result[0].type).toBe('sale');
+    });
+  });
+
+  // =========================================================================
+  // Phase 2: String transaction parsing + structural validation
+  // =========================================================================
+
+  describe('parseStringTransaction: AI string → structured object', () => {
+    it('should parse "Sold 80 Common Stock shares at $412.460 (S, D)"', () => {
+      const result = parseStringTransaction('Sold 80 Common Stock shares at $412.460 (S, D)');
+      expect(result).not.toBeNull();
+      expect(result!.code).toBe('S');
+      expect(result!.type).toBe('Sale');
+      expect(result!.shares).toBe('80');
+      expect(result!.pricePerShare).toBe('$412.460');
+      expect(result!.acquisitionDisposition).toBe('D');
+    });
+
+    it('should parse "Exercised into 40,000 Common Stock shares at $14.99 (M, A)"', () => {
+      const result = parseStringTransaction('Exercised into 40,000 Common Stock shares at $14.99 (M, A)');
+      expect(result).not.toBeNull();
+      expect(result!.code).toBe('M');
+      expect(result!.type).toBe('Exercise');
+      expect(result!.shares).toBe('40,000');
+      expect(result!.pricePerShare).toBe('$14.99');
+      expect(result!.acquisitionDisposition).toBe('A');
+    });
+
+    it('should parse "Exercised 40,000 Non-Qualified Stock Option at $0.000 (M, D)"', () => {
+      const result = parseStringTransaction('Exercised 40,000 Non-Qualified Stock Option at $0.000 (M, D)');
+      expect(result).not.toBeNull();
+      expect(result!.code).toBe('M');
+      expect(result!.shares).toBe('40,000');
+      expect(result!.pricePerShare).toBe('$0.000');
+    });
+
+    it('should parse gift transactions "(G, D)"', () => {
+      const result = parseStringTransaction('Gifted 5,000 shares at $0 (G, D)');
+      expect(result).not.toBeNull();
+      expect(result!.code).toBe('G');
+      expect(result!.type).toBe('Gift');
+    });
+
+    it('should return null for unparseable strings', () => {
+      expect(parseStringTransaction('some random text')).toBeNull();
+      expect(parseStringTransaction('')).toBeNull();
+    });
+
+    it('parsed string transactions should classify correctly', () => {
+      const parsed = parseStringTransaction('Sold 10,000 Common Stock shares at $150 (S, D)')!;
+      const result = aggregateTransactionsByType([parsed]);
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('sale');
+      expect(result[0].totalValue).toBe(1500000);
+    });
+  });
+
+  describe('template structural validation: spread strings filtered out', () => {
+    it('should classify valid structured transactions even when mixed with invalid ones', () => {
+      // When a string is spread: { ...\"Sold 80 shares\" } produces {"0":"S","1":"o",...}
+      // aggregateTransactionsByType gets called with whatever the template passes
+      const spreadString = { '0': 'S', '1': 'o', '2': 'l', '3': 'd' } as unknown as { type?: string; code?: string; shares?: string };
+
+      // The spread string has no type/code/shares — it should not classify as anything
+      const result = aggregateTransactionsByType([spreadString]);
+      // It goes to "other" because no classifier matches, but totalShares/totalValue are 0
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('other');
+      expect(result[0].totalShares).toBe(0);
+      expect(result[0].totalValue).toBe(0);
+    });
+  });
+
+  // =========================================================================
+  // Phase 3: formatSchemaDescription renders array item fields
+  // =========================================================================
+
+  describe('formatSchemaDescription: array item fields visible in prompt', () => {
+    it('should include transaction field names (code, type, shares, pricePerShare) in generated prompt', () => {
+      const prompt = generateFilingPrompt({
+        formType: '4',
+        filingContent: 'test content',
+        ticker: 'TEST',
+      });
+      // The user prompt should contain the inner field names
+      expect(prompt.userPrompt).toContain('"code"');
+      expect(prompt.userPrompt).toContain('"type"');
+      expect(prompt.userPrompt).toContain('"shares"');
+      expect(prompt.userPrompt).toContain('"pricePerShare"');
+    });
+
+    it('should mark inner required fields as REQUIRED in the prompt', () => {
+      const prompt = generateFilingPrompt({
+        formType: '4',
+        filingContent: 'test content',
+        ticker: 'TEST',
+      });
+      // code, type, shares, pricePerShare are required in the items schema
+      expect(prompt.userPrompt).toMatch(/"code".*REQUIRED/);
+      expect(prompt.userPrompt).toMatch(/"shares".*REQUIRED/);
+    });
+
+    it('should include sharesOwnedFollowing field in generated prompt', () => {
+      const prompt = generateFilingPrompt({
+        formType: '4',
+        filingContent: 'test content',
+        ticker: 'TEST',
+      });
+      expect(prompt.userPrompt).toContain('"sharesOwnedFollowing"');
+      expect(prompt.userPrompt).toContain('Beneficially Owned Following');
+    });
+
+    it('Form 4 schema should define sharesOwnedFollowing in transaction items', () => {
+      const schema = FORM_SCHEMAS['4'];
+      const txItems = schema.properties.transactions.items;
+      expect(txItems?.properties).toHaveProperty('sharesOwnedFollowing');
+    });
+  });
+
+  // =========================================================================
+  // Phase 3: Field-name aliasing in normalizer (via parseResponse)
+  // =========================================================================
+
+  describe('normalizer: field-name aliasing for variant AI field names', () => {
+    it('should map transactionCode to code', () => {
+      const aiResponse = JSON.stringify({
+        company: 'Test Corp',
+        summary: 'Test summary',
+        filerName: 'John Doe',
+        transactions: [
+          { transactionCode: 'S', shares: '1,000', pricePerShare: '$100' }
+        ]
+      });
+      const result = parseResponse(aiResponse, '4');
+      const tx = (result.data as Record<string, unknown>).transactions as Record<string, unknown>[];
+      expect(tx[0].code).toBe('S');
+      expect(tx[0].transactionCode).toBeUndefined();
+    });
+
+    it('should map transactionType to type', () => {
+      const aiResponse = JSON.stringify({
+        company: 'Test Corp',
+        summary: 'Test summary',
+        filerName: 'John Doe',
+        transactions: [
+          { code: 'P', transactionType: 'Purchase', shares: '500', pricePerShare: '$50' }
+        ]
+      });
+      const result = parseResponse(aiResponse, '4');
+      const tx = (result.data as Record<string, unknown>).transactions as Record<string, unknown>[];
+      expect(tx[0].type).toBe('Purchase');
+      expect(tx[0].transactionType).toBeUndefined();
+    });
+
+    it('should infer code from type when code is empty', () => {
+      const aiResponse = JSON.stringify({
+        company: 'Test Corp',
+        summary: 'Test summary',
+        filerName: 'John Doe',
+        transactions: [
+          { code: '', type: 'Sale', shares: '10,000', pricePerShare: '$150' }
+        ]
+      });
+      const result = parseResponse(aiResponse, '4');
+      const tx = (result.data as Record<string, unknown>).transactions as Record<string, unknown>[];
+      expect(tx[0].code).toBe('S');
+    });
+
+    it('should infer type from code when type is empty', () => {
+      const aiResponse = JSON.stringify({
+        company: 'Test Corp',
+        summary: 'Test summary',
+        filerName: 'John Doe',
+        transactions: [
+          { code: 'G', type: '', shares: '5,000', pricePerShare: '$0' }
+        ]
+      });
+      const result = parseResponse(aiResponse, '4');
+      const tx = (result.data as Record<string, unknown>).transactions as Record<string, unknown>[];
+      expect(tx[0].type).toBe('Gift');
+    });
+
+    it('should not overwrite existing code when transactionCode also present', () => {
+      const aiResponse = JSON.stringify({
+        company: 'Test Corp',
+        summary: 'Test summary',
+        filerName: 'John Doe',
+        transactions: [
+          { code: 'S', transactionCode: 'P', shares: '1,000', pricePerShare: '$100' }
+        ]
+      });
+      const result = parseResponse(aiResponse, '4');
+      const tx = (result.data as Record<string, unknown>).transactions as Record<string, unknown>[];
+      expect(tx[0].code).toBe('S'); // Original code preserved
+    });
+
+    it('aliased transactions should classify correctly downstream', () => {
+      // Simulate what NVDA E2E produced: transactionCode instead of code
+      const nvdaTx = { transactionCode: 'A', shares: 55558, pricePerShare: '$0' };
+      const aiResponse = JSON.stringify({
+        company: 'NVIDIA',
+        summary: 'Stock awards',
+        filerName: 'Test Person',
+        transactions: [nvdaTx]
+      });
+      const result = parseResponse(aiResponse, '4');
+      const tx = (result.data as Record<string, unknown>).transactions as Record<string, unknown>[];
+      // After normalizer aliasing, aggregation should classify as award
+      const classified = aggregateTransactionsByType(tx);
+      expect(classified[0].type).toBe('award');
+    });
+  });
+
+  // =========================================================================
+  // Phase 3: Post-transaction ownership → newStake derivation
+  // =========================================================================
+
+  describe('normalizer: sharesOwnedFollowing → newStake derivation', () => {
+    it('should derive newStake from last transactions sharesOwnedFollowing', () => {
+      const aiResponse = JSON.stringify({
+        company: 'Test Corp',
+        summary: 'Insider sale',
+        filerName: 'John Doe',
+        transactions: [
+          { code: 'S', type: 'Sale', shares: '10,000', pricePerShare: '$100', sharesOwnedFollowing: '90,000' },
+          { code: 'S', type: 'Sale', shares: '5,000', pricePerShare: '$101', sharesOwnedFollowing: '85,000' }
+        ]
+      });
+      const result = parseResponse(aiResponse, '4');
+      const data = result.data as Record<string, unknown>;
+      expect(data.newStake).toBe('85000 shares'); // Last transaction's post-ownership
+    });
+
+    it('should not overwrite existing newStake', () => {
+      const aiResponse = JSON.stringify({
+        company: 'Test Corp',
+        summary: 'Insider sale',
+        filerName: 'John Doe',
+        newStake: '100,000 shares',
+        transactions: [
+          { code: 'S', type: 'Sale', shares: '10,000', pricePerShare: '$100', sharesOwnedFollowing: '90,000' }
+        ]
+      });
+      const result = parseResponse(aiResponse, '4');
+      const data = result.data as Record<string, unknown>;
+      expect(data.newStake).toBe('100,000 shares'); // Existing value preserved
+    });
+
+    it('should skip sharesOwnedFollowing when empty/missing', () => {
+      const aiResponse = JSON.stringify({
+        company: 'Test Corp',
+        summary: 'Insider sale',
+        filerName: 'John Doe',
+        transactions: [
+          { code: 'S', type: 'Sale', shares: '10,000', pricePerShare: '$100' }
+        ]
+      });
+      const result = parseResponse(aiResponse, '4');
+      const data = result.data as Record<string, unknown>;
+      expect(data.newStake).toBeUndefined();
+    });
+
+    it('should strip bracket artifacts from sharesOwnedFollowing', () => {
+      const aiResponse = JSON.stringify({
+        company: 'Test Corp',
+        summary: 'Insider award',
+        filerName: 'John Doe',
+        transactions: [
+          { code: 'A', type: 'Award', shares: '103,278', pricePerShare: '$0', sharesOwnedFollowing: '659,729]' }
+        ]
+      });
+      const result = parseResponse(aiResponse, '4');
+      const data = result.data as Record<string, unknown>;
+      expect(data.newStake).toBe('659729 shares');
+      expect(data.newStake).not.toContain(']');
+    });
+  });
+
+  // =========================================================================
+  // Phase 4: previousStake + percentageChange derivation
+  // =========================================================================
+
+  describe('normalizer: previousStake derivation from transactions', () => {
+    it('should derive previousStake for a sale (disposition)', () => {
+      const aiResponse = JSON.stringify({
+        company: 'Test Corp',
+        summary: 'Insider sale',
+        filerName: 'John Doe',
+        transactions: [
+          { code: 'S', type: 'Sale', shares: '10,000', pricePerShare: '$100', acquisitionDisposition: 'D', sharesOwnedFollowing: '90,000' }
+        ]
+      });
+      const result = parseResponse(aiResponse, '4');
+      const data = result.data as Record<string, unknown>;
+      expect(data.previousStake).toBe('100000 shares'); // 90000 + 10000
+      expect(data.newStake).toBe('90000 shares');
+    });
+
+    it('should derive previousStake for an award (acquisition)', () => {
+      const aiResponse = JSON.stringify({
+        company: 'Test Corp',
+        summary: 'Stock award',
+        filerName: 'John Doe',
+        transactions: [
+          { code: 'A', type: 'Award', shares: '50,000', pricePerShare: '$0', acquisitionDisposition: 'A', sharesOwnedFollowing: '150,000' }
+        ]
+      });
+      const result = parseResponse(aiResponse, '4');
+      const data = result.data as Record<string, unknown>;
+      expect(data.previousStake).toBe('100000 shares'); // 150000 - 50000
+      expect(data.newStake).toBe('150000 shares');
+    });
+
+    it('should derive previousStake for sale inferred from code S', () => {
+      // No explicit acquisitionDisposition, but code S implies disposition
+      const aiResponse = JSON.stringify({
+        company: 'Coca-Cola',
+        summary: 'Insider sale',
+        filerName: 'Jane Smith',
+        transactions: [
+          { code: 'S', type: 'Sale', shares: '5,000', pricePerShare: '$60', sharesOwnedFollowing: '223,330' }
+        ]
+      });
+      const result = parseResponse(aiResponse, '4');
+      const data = result.data as Record<string, unknown>;
+      expect(data.previousStake).toBe('228330 shares'); // 223330 + 5000
+    });
+
+    it('should derive percentageChange from previousStake and newStake', () => {
+      const aiResponse = JSON.stringify({
+        company: 'Test Corp',
+        summary: 'Insider sale',
+        filerName: 'John Doe',
+        transactions: [
+          { code: 'S', type: 'Sale', shares: '10,000', pricePerShare: '$100', acquisitionDisposition: 'D', sharesOwnedFollowing: '90,000' }
+        ]
+      });
+      const result = parseResponse(aiResponse, '4');
+      const data = result.data as Record<string, unknown>;
+      expect(data.percentageChange).toBe('-10.00%'); // (90000 - 100000) / 100000 = -10%
+    });
+
+    it('should show positive percentageChange for acquisitions', () => {
+      const aiResponse = JSON.stringify({
+        company: 'Test Corp',
+        summary: 'Stock award',
+        filerName: 'John Doe',
+        transactions: [
+          { code: 'A', type: 'Award', shares: '50,000', pricePerShare: '$0', acquisitionDisposition: 'A', sharesOwnedFollowing: '150,000' }
+        ]
+      });
+      const result = parseResponse(aiResponse, '4');
+      const data = result.data as Record<string, unknown>;
+      expect(data.percentageChange).toBe('50.00%'); // (150000 - 100000) / 100000 = +50%
+    });
+
+    it('should not derive previousStake when already set', () => {
+      const aiResponse = JSON.stringify({
+        company: 'Test Corp',
+        summary: 'Insider sale',
+        filerName: 'John Doe',
+        previousStake: '200,000 shares',
+        transactions: [
+          { code: 'S', type: 'Sale', shares: '10,000', pricePerShare: '$100', acquisitionDisposition: 'D', sharesOwnedFollowing: '90,000' }
+        ]
+      });
+      const result = parseResponse(aiResponse, '4');
+      const data = result.data as Record<string, unknown>;
+      expect(data.previousStake).toBe('200,000 shares');
+    });
+
+    it('should use first tx for previousStake with multiple transactions', () => {
+      const aiResponse = JSON.stringify({
+        company: 'Tesla',
+        summary: 'Multiple insider transactions',
+        filerName: 'Elon Musk',
+        transactions: [
+          { code: 'M', type: 'Exercise', shares: '10,000', pricePerShare: '$25', acquisitionDisposition: 'A', sharesOwnedFollowing: '110,000' },
+          { code: 'S', type: 'Sale', shares: '5,000', pricePerShare: '$250', acquisitionDisposition: 'D', sharesOwnedFollowing: '105,000' }
+        ]
+      });
+      const result = parseResponse(aiResponse, '4');
+      const data = result.data as Record<string, unknown>;
+      // First tx: Exercise (acquisition), shares=10000, after=110000 → before = 110000 - 10000 = 100000
+      expect(data.previousStake).toBe('100000 shares');
+      // Last tx: after=105000
+      expect(data.newStake).toBe('105000 shares');
+      // Change: (105000 - 100000) / 100000 = +5%
+      expect(data.percentageChange).toBe('5.00%');
+    });
+  });
+
+  // =========================================================================
+  // Phase 4: Bracket artifact cleanup
+  // =========================================================================
+
+  describe('normalizer: bracket artifact cleanup', () => {
+    it('should strip brackets from code field', () => {
+      const aiResponse = JSON.stringify({
+        company: 'Test Corp',
+        summary: 'Test',
+        filerName: 'John Doe',
+        transactions: [
+          { code: 'A]', type: 'Award', shares: '100', pricePerShare: '$0' }
+        ]
+      });
+      const result = parseResponse(aiResponse, '4');
+      const tx = (result.data as Record<string, unknown>).transactions as Record<string, unknown>[];
+      expect(tx[0].code).toBe('A');
+    });
+
+    it('should strip brackets from shares field', () => {
+      const aiResponse = JSON.stringify({
+        company: 'Test Corp',
+        summary: 'Test',
+        filerName: 'John Doe',
+        transactions: [
+          { code: 'S', type: 'Sale', shares: '[10,000]', pricePerShare: '$100' }
+        ]
+      });
+      const result = parseResponse(aiResponse, '4');
+      const tx = (result.data as Record<string, unknown>).transactions as Record<string, unknown>[];
+      expect(tx[0].shares).toBe('10,000');
+    });
+  });
+});

--- a/components/ui/email/templates/8k-minimalist-template.tsx
+++ b/components/ui/email/templates/8k-minimalist-template.tsx
@@ -459,13 +459,20 @@ export function Form8KMinimalistTemplate({ filing }: Form8KMinimalistTemplatePro
                         <tbody>
                           {keyHighlights.slice(0, 5).map((highlight, index) => (
                             <tr key={index}>
+                              <td valign="top" width="16" style={{
+                                padding: '4px 0',
+                                fontSize: '14px',
+                                lineHeight: '1.5',
+                                color: EmailColors.text.meta,
+                              }}>
+                                •
+                              </td>
                               <td style={{
                                 padding: '4px 0',
                                 fontSize: '14px',
                                 lineHeight: '1.5',
                                 color: EmailColors.text.body,
                               }}>
-                                <span style={{ marginRight: '8px', color: EmailColors.text.meta }}>•</span>
                                 <span dangerouslySetInnerHTML={{ __html: formatText(highlight) }} />
                               </td>
                             </tr>

--- a/components/ui/email/templates/8k-minimalist-template.tsx
+++ b/components/ui/email/templates/8k-minimalist-template.tsx
@@ -460,7 +460,8 @@ export function Form8KMinimalistTemplate({ filing }: Form8KMinimalistTemplatePro
                           {keyHighlights.slice(0, 5).map((highlight, index) => (
                             <tr key={index}>
                               <td valign="top" width="16" style={{
-                                padding: '4px 0',
+                                width: '16px',
+                                padding: '4px 8px 4px 0',
                                 fontSize: '14px',
                                 lineHeight: '1.5',
                                 color: EmailColors.text.meta,

--- a/components/ui/email/templates/form144-minimalist-template.tsx
+++ b/components/ui/email/templates/form144-minimalist-template.tsx
@@ -122,7 +122,12 @@ function getSignalConfig(isNotable: boolean, has10b51: boolean) {
 function formatText(text: string): string {
   if (!text) return '';
   let html = text;
+  // Escape all HTML entities to prevent XSS from AI-generated content
   html = html.replace(/&(?!amp;|lt;|gt;|quot;|#)/g, '&amp;');
+  html = html.replace(/</g, '&lt;');
+  html = html.replace(/>/g, '&gt;');
+  html = html.replace(/"/g, '&quot;');
+  html = html.replace(/'/g, '&#39;');
   // Bold dollar amounts
   html = html.replace(
     /(\$[\d,]+(?:\.\d+)?[KMB]?)/g,
@@ -405,6 +410,7 @@ export function Form144MinimalistTemplate({ filing }: Form144MinimalistTemplateP
               {shares && remainingHoldings && parseNumericValue(remainingHoldings) > 0 && (() => {
                 const sharesNum = parseNumericValue(shares);
                 const remainingNum = parseNumericValue(remainingHoldings);
+                if (!Number.isFinite(sharesNum) || !Number.isFinite(remainingNum)) return null;
                 const outstandingNum = parseNumericValue(sharesOutstanding);
                 const beforeNum = sharesNum + remainingNum;
                 const pctChange = beforeNum > 0 ? -((sharesNum / beforeNum) * 100) : 0;

--- a/components/ui/email/templates/form144-minimalist-template.tsx
+++ b/components/ui/email/templates/form144-minimalist-template.tsx
@@ -176,6 +176,7 @@ export function Form144MinimalistTemplate({ filing }: Form144MinimalistTemplateP
   const tradingPlan = (data?.tradingPlan || extractedData?.tradingPlan || '') as string;
   const signalStrength = (data?.signalStrength || extractedData?.signalStrength || '') as string;
   const remainingHoldings = (data?.remainingHoldings || data?.sharesRemaining || extractedData?.remainingHoldings || '') as string;
+  const sharesOutstanding = (data?.sharesOutstanding || '') as string;
   const investorImplication = (data?.investorImplication || extractedData?.investorImplication || '') as string;
 
   const displayTicker = symbol || ticker || 'N/A';
@@ -373,7 +374,7 @@ export function Form144MinimalistTemplate({ filing }: Form144MinimalistTemplateP
                                   }}>
                                     {shares}
                                   </div>
-                                  {remainingHoldings && (
+                                  {remainingHoldings && parseNumericValue(remainingHoldings) > 0 && (
                                     <div style={{
                                       fontSize: '12px',
                                       color: '#991B1B',
@@ -393,6 +394,92 @@ export function Form144MinimalistTemplate({ filing }: Form144MinimalistTemplateP
                   </tbody>
                 </table>
               )}
+
+              {/* ═══════════════════════════════════════════════════════════
+                  OWNERSHIP IMPACT - Before/after ownership comparison
+                  Matches Form 4 visual: before → ↓ → after (percentage)
+                  ═══════════════════════════════════════════════════════════ */}
+              {/* Ownership Impact: Only show when we have the insider's actual remaining holdings.
+                  sharesOutstanding is the issuer's total class outstanding — NOT the insider's position.
+                  Showing issuer-level data as "ownership impact" is misleading for director/officer filers. */}
+              {shares && remainingHoldings && parseNumericValue(remainingHoldings) > 0 && (() => {
+                const sharesNum = parseNumericValue(shares);
+                const remainingNum = parseNumericValue(remainingHoldings);
+                const outstandingNum = parseNumericValue(sharesOutstanding);
+                const beforeNum = sharesNum + remainingNum;
+                const pctChange = beforeNum > 0 ? -((sharesNum / beforeNum) * 100) : 0;
+                const pctColor = '#DC2626'; // Sales are always red
+                const pctDisplay = `${pctChange.toFixed(1)}%`;
+
+                return (
+                  <table width="100%" cellPadding="0" cellSpacing="0" style={{ marginBottom: '16px' }}>
+                    <tbody>
+                      <tr>
+                        <td style={{
+                          padding: '16px',
+                          backgroundColor: EmailColors.structure.backgroundAlt,
+                          borderRadius: '8px',
+                          textAlign: 'center',
+                        }}>
+                          <div style={{
+                            fontSize: '11px',
+                            fontWeight: 700,
+                            color: EmailColors.text.meta,
+                            textTransform: 'uppercase' as const,
+                            letterSpacing: '0.5px',
+                            marginBottom: '8px',
+                          }}>
+                            Ownership Impact
+                          </div>
+                          {/* Previous ownership (before sale) */}
+                          <div style={{
+                            fontSize: '14px',
+                            color: EmailColors.text.muted,
+                            marginBottom: '6px',
+                          }}>
+                            {beforeNum.toLocaleString()} shares
+                          </div>
+                          {/* Direction arrow */}
+                          <div style={{
+                            fontSize: '20px',
+                            lineHeight: '1',
+                            margin: '4px 0',
+                            color: pctColor,
+                          }}>
+                            ↓
+                          </div>
+                          {/* New ownership (after sale) */}
+                          <div style={{
+                            fontSize: '16px',
+                            fontWeight: 700,
+                            color: EmailColors.text.headline,
+                            marginTop: '6px',
+                          }}>
+                            {remainingNum.toLocaleString()} shares
+                            <span style={{
+                              marginLeft: '8px',
+                              fontSize: '14px',
+                              fontWeight: 600,
+                              color: pctColor,
+                            }}>
+                              ({pctDisplay})
+                            </span>
+                          </div>
+                          {outstandingNum > 0 && (
+                            <div style={{
+                              fontSize: '11px',
+                              color: EmailColors.text.meta,
+                              marginTop: '8px',
+                            }}>
+                              of {outstandingNum.toLocaleString()} class shares outstanding
+                            </div>
+                          )}
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                );
+              })()}
 
               {/* ═══════════════════════════════════════════════════════════
                   THE STORY - Summary with key values highlighted

--- a/components/ui/email/templates/form4-minimalist-template.tsx
+++ b/components/ui/email/templates/form4-minimalist-template.tsx
@@ -314,7 +314,7 @@ export function aggregateTransactionsByType(transactions: TransactionData[]): Ag
     }
 
     const shares = Math.round(parseNumericValue(tx.shares));
-    const price = parseNumericValue(tx.pricePerShare);
+    const price = parseNumericValue(tx.pricePerShare ?? (tx as Record<string, unknown>).price);
 
     // Calculate value: prefer totalValue if it's meaningful (> 0), otherwise calculate from shares * price
     let value = 0;
@@ -450,7 +450,7 @@ export function getTransactionTypeConfig(type: string): TransactionTypeConfig {
   // Exercise/Derivative type (label covers exercises + expirations)
   if (typeLower.includes('exercise') || typeLower.includes('conversion') || typeLower.includes('expir') || typeLower.includes('derivative')) {
     return {
-      label: 'Derivative Activity',
+      label: 'Exercised Options',
       icon: '⚡',
       bgColor: '#F0FDFA',
       textColor: '#115E59',
@@ -620,7 +620,11 @@ export function Form4MinimalistTemplate({ filing }: Form4MinimalistTemplateProps
   const filerRole = (data?.relationship || data?.position || extractedData?.relationship || '') as string;
 
   // Merge transactions from both sources
-  const dataTransactions = (data?.transactions || []) as TransactionData[];
+  const rawTransactions = (data?.transactions || []) as Array<TransactionData & { price?: string | number }>;
+  const dataTransactions = rawTransactions.map(t => ({
+    ...t,
+    pricePerShare: t.pricePerShare ?? t.price,
+  })) as TransactionData[];
   const extractedTransactions = hasExtractedData ? extractedData.transactions.map(t => ({
     type: t.type,
     shares: t.shares,
@@ -629,7 +633,9 @@ export function Form4MinimalistTemplate({ filing }: Form4MinimalistTemplateProps
     acquisitionDisposition: t.acquisitionDisposition,
     code: t.code,
   })) : [];
-  const transactions = dataTransactions.length > 0 ? dataTransactions : extractedTransactions;
+  // Filter out structurally invalid transactions (e.g., spread strings produce {"0":"S","1":"o",...})
+  const validTransactions = dataTransactions.filter(t => t.type || t.code || t.shares);
+  const transactions = validTransactions.length > 0 ? validTransactions : extractedTransactions;
   const firstTx = transactions[0] || {};
 
   const percentChange = (data?.percentageChange || data?.changePercent || extractedData?.percentageChange || '') as string;
@@ -910,7 +916,15 @@ export function Form4MinimalistTemplate({ filing }: Form4MinimalistTemplateProps
                 (previousStake && newStake) || // Have before/after comparison
                 (newStake && percentChange) || // Have new stake with change
                 (previousStake && percentChange) // Have previous stake with change
-              ) && (
+              ) && (() => {
+                // Parse percentage for color logic (handles "-10.00%", "50.00%", "+5.0%")
+                const pctNum = parseFloat((percentChange || '0').replace(/[%+]/g, ''));
+                const pctColor = pctNum < 0 ? '#DC2626' : pctNum > 0 ? '#16A34A' : EmailColors.text.meta;
+                const pctDisplay = percentChange
+                  ? (pctNum > 0 && !percentChange.startsWith('+') ? `+${percentChange}` : percentChange)
+                  : '';
+
+                return (
                 <table width="100%" cellPadding="0" cellSpacing="0" style={{ marginBottom: '16px' }}>
                   <tbody>
                     <tr>
@@ -946,7 +960,7 @@ export function Form4MinimalistTemplate({ filing }: Form4MinimalistTemplateProps
                                 fontSize: '20px',
                                 lineHeight: '1',
                                 margin: '4px 0',
-                                color: percentChange?.startsWith('-') ? '#DC2626' : percentChange?.startsWith('+') ? '#16A34A' : EmailColors.text.meta,
+                                color: pctColor,
                               }}>
                                 ↓
                               </div>
@@ -958,14 +972,14 @@ export function Form4MinimalistTemplate({ filing }: Form4MinimalistTemplateProps
                                 marginTop: '6px',
                               }}>
                                 {newStake}
-                                {percentChange && (
+                                {pctDisplay && (
                                   <span style={{
                                     marginLeft: '8px',
                                     fontSize: '14px',
                                     fontWeight: 600,
-                                    color: percentChange.startsWith('-') ? '#DC2626' : percentChange.startsWith('+') ? '#16A34A' : EmailColors.text.meta,
+                                    color: pctColor,
                                   }}>
-                                    ({percentChange})
+                                    ({pctDisplay})
                                   </span>
                                 )}
                               </div>
@@ -978,14 +992,14 @@ export function Form4MinimalistTemplate({ filing }: Form4MinimalistTemplateProps
                               color: EmailColors.text.headline,
                             }}>
                               {newStake || previousStake}
-                              {percentChange && (
+                              {pctDisplay && (
                                 <span style={{
                                   marginLeft: '8px',
                                   fontSize: '14px',
                                   fontWeight: 600,
-                                  color: percentChange.startsWith('-') ? '#DC2626' : percentChange.startsWith('+') ? '#16A34A' : EmailColors.text.meta,
+                                  color: pctColor,
                                 }}>
-                                  ({percentChange})
+                                  ({pctDisplay})
                                 </span>
                               )}
                             </div>
@@ -995,7 +1009,8 @@ export function Form4MinimalistTemplate({ filing }: Form4MinimalistTemplateProps
                     </tr>
                   </tbody>
                 </table>
-              )}
+                );
+              })()}
 
               {/* ═══════════════════════════════════════════════════════════
                   THE STORY - One-liner summary

--- a/components/ui/email/templates/form4-minimalist-template.tsx
+++ b/components/ui/email/templates/form4-minimalist-template.tsx
@@ -955,14 +955,14 @@ export function Form4MinimalistTemplate({ filing }: Form4MinimalistTemplateProps
                               }}>
                                 {previousStake}
                               </div>
-                              {/* Direction arrow - always points down (old → new visual flow); color shows sentiment */}
+                              {/* Direction arrow - matches sentiment direction */}
                               <div style={{
                                 fontSize: '20px',
                                 lineHeight: '1',
                                 margin: '4px 0',
                                 color: pctColor,
                               }}>
-                                ↓
+                                {pctNum > 0 ? '↑' : '↓'}
                               </div>
                               {/* New ownership (after transaction) */}
                               <div style={{

--- a/docs/plans/2026-03-04-fix-form4-classification-data-flow.md
+++ b/docs/plans/2026-03-04-fix-form4-classification-data-flow.md
@@ -1,0 +1,405 @@
+# Fix Form 4 Transaction Classification Not Working in Production
+
+**Date**: 2026-03-04 08:29:54 AEDT
+**Git Commit**: e633c2eb724836e2d5d6bdb6c22e6e9f150e48b7
+**Branch**: worktree-summary-enhancements
+**Repository**: tldrsec-ai
+**Reviewed**: 2026-03-05 — 4 issues found, all resolved
+
+## Overview
+
+PR #356 (merged Feb 25, commit `91e4fb7`) added 7-bucket Form 4 transaction classification (purchase, sale, award, exercise, gift, transfer, other). Users report enhancements aren't visible in delivered emails over the last 3 days.
+
+**Root cause**: Two data flow gaps between the AI prompt schema and the email template:
+1. The AI schema lacked a `code` field — classification functions check `tx.code` first, which was always undefined
+2. The AI schema uses field name `price` but the template reads `pricePerShare` — all prices/values render as $0
+
+The classification functions themselves work correctly (21-code coverage tests pass). They just never receive the data they need.
+
+**Issues addressed:**
+1. `tx.code` always undefined in production summaryJSON (AI schema had no `code` field)
+2. `tx.pricePerShare` always undefined because AI outputs `price` (field name mismatch)
+3. Text fallback fails: AI outputs `type: "Acquisition"` for code A, but `isAwardTransaction()` checks for "award"/"grant"/"rsu" — "acquisition" doesn't match
+
+## Current State Analysis
+
+### What's Already Done in This Worktree
+- `lib/ai/prompts/unified-prompts.ts`: `code` field added to Form 4 transaction schema, marked as REQUIRED
+- `type` field description updated: "Human-readable transaction type: Purchase, Sale, Award/Grant, Gift, Exercise, Disposition, Transfer"
+
+### What's Still Broken
+
+**Field name mismatch**: AI schema has `price`, template `TransactionData` interface has `pricePerShare`
+- `unified-prompts.ts:337` → `price: { type: 'string', ... }`
+- `form4-minimalist-template.tsx:18` → `pricePerShare?: string | number`
+- `aggregateTransactionsByType()` reads `tx.pricePerShare` → undefined → `parseNumericValue(undefined)` → 0
+
+**Data flow trace:**
+```
+AI Output (summaryJSON)           Template (TransactionData)
+─────────────────────            ────────────────────────────
+transactions[]:                   dataTransactions cast as TransactionData[]:
+  code: "A"          ──────→      code: "A"         ✅ (new field, works)
+  type: "Award/Grant" ─────→      type: "Award/Grant" ✅ (text fallback now works)
+  shares: "2,500"    ──────→      shares: "2,500"    ✅
+  price: "$0"        ──────→      pricePerShare: ???  ✗ (field name mismatch)
+                                  totalValue: ???     ✗ (not in per-tx AI schema)
+```
+
+**Template transaction selection** (`form4-minimalist-template.tsx:632`):
+```typescript
+const transactions = dataTransactions.length > 0 ? dataTransactions : extractedTransactions;
+```
+AI transactions array is always non-empty (REQUIRED field), so extractor transactions (which DO have correct field names) are never used.
+
+### Key Discoveries:
+- Classification functions at `form4-minimalist-template.tsx:101-263` all check `tx.code` FIRST — once `code` is present, classification works correctly
+- `mergeWithFallback()` at `extractor-merge-utils.ts:106` uses "AI wins on non-empty" — AI's non-empty `transactions` array prevents extractor enrichment
+- Existing regression tests (`summary-quality-2026-02-18.test.ts:49-70`) construct data with `code` explicitly, hiding the production gap
+- The Form 4 extraction guidance at `unified-prompts.ts:998-1029` already has comprehensive code mapping, ensuring AI will output correct `code` values
+
+## What We're NOT Doing
+
+- NOT fixing shared summary cache re-enrichment — once AI outputs `code` + `pricePerShare`, shared copies carry correct data
+- NOT changing merge strategy — merge works correctly; issue was missing data, not wrong merge logic
+- NOT modifying classification functions — they work correctly when `code` is present (but adding `price` fallback in `aggregateTransactionsByType` per review)
+- NOT adding cache invalidation for old summaries — natural aging handles this
+- NOT changing extractor logic — extractor is a fallback, primary path through AI data is being fixed
+
+---
+
+## Phase 1: Failing Tests for AI-Schema-to-Template Data Flow
+
+### Overview
+Write regression tests that use data shaped exactly like actual AI output. These expose the `price` → `pricePerShare` field name mismatch.
+
+### Step 1.1: 🔴 Write Failing Tests
+
+**Test File**: `__tests__/regression/form4-ai-schema-classification.test.ts`
+
+```typescript
+/**
+ * Form 4 AI Schema → Template Classification Regression Tests
+ *
+ * These tests verify that data shaped like ACTUAL AI output (from unified-prompts.ts)
+ * classifies correctly in the email template.
+ *
+ * Key difference from summary-quality-2026-02-18.test.ts: those tests provide `code`
+ * explicitly with template-native field names. These tests use AI-schema field names
+ * (e.g., `price` instead of `pricePerShare`) to catch data flow mismatches.
+ */
+
+import {
+  aggregateTransactionsByType,
+} from '../../components/ui/email/templates/form4-minimalist-template';
+
+// Helper: create transaction shaped like AI output (unified-prompts.ts Form 4 schema)
+function aiTx(overrides: {
+  code: string;
+  type: string;
+  shares: string;
+  price: string;          // AI field name (NOT pricePerShare)
+  date?: string;
+  acquisitionDisposition?: string;
+}) {
+  return overrides;
+}
+
+describe('Form 4: AI Schema → Template Classification', () => {
+  describe('code field enables correct classification', () => {
+    it('should classify code A + type "Award/Grant" as award (not other)', () => {
+      const transactions = [
+        aiTx({ code: 'A', type: 'Award/Grant', shares: '2,500', price: '$0', acquisitionDisposition: 'A' }),
+      ];
+      const result = aggregateTransactionsByType(transactions);
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('award');
+    });
+
+    it('should classify code S + type "Sale" as sale', () => {
+      const transactions = [
+        aiTx({ code: 'S', type: 'Sale', shares: '10,000', price: '$150.50', acquisitionDisposition: 'D' }),
+      ];
+      const result = aggregateTransactionsByType(transactions);
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('sale');
+    });
+
+    it('should classify code G + type "Gift" as gift', () => {
+      const transactions = [
+        aiTx({ code: 'G', type: 'Gift', shares: '5,000', price: '$0', acquisitionDisposition: 'D' }),
+      ];
+      const result = aggregateTransactionsByType(transactions);
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('gift');
+    });
+
+    it('should classify code P + type "Purchase" as purchase', () => {
+      const transactions = [
+        aiTx({ code: 'P', type: 'Purchase', shares: '1,000', price: '$200', acquisitionDisposition: 'A' }),
+      ];
+      const result = aggregateTransactionsByType(transactions);
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('purchase');
+    });
+
+    it('should classify code M + type "Exercise" as exercise', () => {
+      const transactions = [
+        aiTx({ code: 'M', type: 'Exercise', shares: '5,000', price: '$25', acquisitionDisposition: 'A' }),
+      ];
+      const result = aggregateTransactionsByType(transactions);
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('exercise');
+    });
+  });
+
+  describe('price field maps to dollar values (not $0)', () => {
+    it('should compute correct totalValue from AI price field', () => {
+      const transactions = [
+        aiTx({ code: 'S', type: 'Sale', shares: '10,000', price: '$150', acquisitionDisposition: 'D' }),
+      ];
+      const result = aggregateTransactionsByType(transactions);
+      expect(result[0].totalValue).toBe(1500000); // 10000 * 150
+      expect(result[0].totalValue).not.toBe(0);
+    });
+
+    it('should show shares for $0 gift transactions (not misleading "$0")', () => {
+      const transactions = [
+        aiTx({ code: 'G', type: 'Gift', shares: '73,252', price: '$0', acquisitionDisposition: 'D' }),
+      ];
+      const result = aggregateTransactionsByType(transactions);
+      expect(result[0].type).toBe('gift');
+      expect(result[0].totalShares).toBe(73252);
+      expect(result[0].totalValue).toBe(0);
+    });
+  });
+
+  describe('backward compatibility: old summaryJSON with price field', () => {
+    it('should handle transaction with price (no pricePerShare) from old DB records', () => {
+      // Old summaryJSON stored price as "price", not "pricePerShare"
+      const oldFormatTx = { code: 'S', type: 'Sale', shares: '5,000', price: '$100' };
+      const result = aggregateTransactionsByType([oldFormatTx]);
+      expect(result[0].type).toBe('sale');
+      expect(result[0].totalValue).toBe(500000);
+    });
+  });
+
+  describe('type-only fallback (no code field)', () => {
+    it('should classify type "Award/Grant" as award when code is missing', () => {
+      const tx = { type: 'Award/Grant', shares: '2,500', price: '$0' };
+      const result = aggregateTransactionsByType([tx]);
+      expect(result[0].type).toBe('award');
+    });
+
+    it('should classify type "Sale" as sale when code is missing', () => {
+      const tx = { type: 'Sale', shares: '10,000', price: '$150' };
+      const result = aggregateTransactionsByType([tx]);
+      expect(result[0].type).toBe('sale');
+    });
+  });
+});
+```
+
+**Checkpoint 1.1**: Run tests, verify they FAIL on `totalValue`:
+```bash
+npm run test -- --testPathPattern="form4-ai-schema-classification"
+# Expected: classification tests PASS (code field works), but totalValue tests FAIL (price mismatch)
+```
+
+### Step 1.2: 🟢 Implement Fixes
+
+#### 1.2.1 Rename `price` → `pricePerShare` in AI Schema
+**File**: `lib/ai/prompts/unified-prompts.ts` (line ~337)
+**Change**: In Form 4 transaction schema properties, rename `price` key to `pricePerShare`. Update `required` array too.
+
+Before:
+```typescript
+price: { type: 'string', description: 'REQUIRED: Price per share with $ from column 4...' },
+...
+required: ['code', 'type', 'shares', 'price']
+```
+
+After:
+```typescript
+pricePerShare: { type: 'string', description: 'REQUIRED: Price per share with $ from column 4...' },
+...
+required: ['code', 'type', 'shares', 'pricePerShare']
+```
+
+#### 1.2.2 Add Backward-Compat Mapping in Template
+**File**: `components/ui/email/templates/form4-minimalist-template.tsx` (line ~623)
+**Change**: When reading transactions from summaryJSON, map old `price` field to `pricePerShare`:
+
+Before:
+```typescript
+const dataTransactions = (data?.transactions || []) as TransactionData[];
+```
+
+After:
+```typescript
+const rawTransactions = (data?.transactions || []) as Array<TransactionData & { price?: string | number }>;
+const dataTransactions = rawTransactions.map(t => ({
+  ...t,
+  pricePerShare: t.pricePerShare ?? t.price,
+})) as TransactionData[];
+```
+
+#### 1.2.3 Add `price` Fallback in `aggregateTransactionsByType`
+**File**: `components/ui/email/templates/form4-minimalist-template.tsx` (line ~317)
+**Change**: Make the aggregation function defensively handle both `pricePerShare` and `price` field names.
+**Rationale**: Tests call `aggregateTransactionsByType` directly (not through the template). Without this, totalValue tests would never pass. Also protects any future callers.
+
+Before:
+```typescript
+const price = parseNumericValue(tx.pricePerShare);
+```
+
+After:
+```typescript
+const price = parseNumericValue(tx.pricePerShare ?? (tx as Record<string, unknown>).price);
+```
+
+**Checkpoint 1.2.3**: All new tests pass:
+```bash
+npm run test -- --testPathPattern="form4-ai-schema-classification"
+# Expected: All passing (classification + totalValue + backward-compat + type-only fallback)
+```
+
+### Step 1.3: 🔵 Refactor
+- No refactoring needed — changes are minimal and clean
+
+### Step 1.4: Final Phase Verification
+
+#### Automated Verification:
+- [x] New regression tests pass: `npm run test -- --testPathPattern="form4-ai-schema-classification"` (10/10 pass)
+- [x] Existing regression tests pass: `npm run test -- --testPathPattern="summary-quality-2026-02-18"` (42/42 pass)
+- [x] Full test suite passes: `npm run test` (189/189 form4+summary tests pass)
+- [x] Lint passes: `npm run lint` (no errors in changed files; 3 pre-existing warnings in unrelated files)
+- [x] Build succeeds: `npm run build`
+
+#### Manual Verification:
+- [x] Run `npm run test:e2e` with a Form 4 filing to verify `code` appears in AI output (5/5 passed: TSLA 4, VRT 8-K, COIN 144, KO 4, NVDA 4)
+- [ ] Check delivered email shows correct transaction type labels
+
+**STOP**: Await manual confirmation before proceeding.
+
+---
+
+## Testing Strategy
+
+### TDD Test Design Principles
+The key insight from research: existing tests pass because they provide `code` explicitly using template-native field names. Nobody tested with actual AI-shaped data. New tests must use AI output format (`price` not `pricePerShare`).
+
+### Checkpoint Frequency
+- Checkpoint 1.1: Tests fail as expected (field mismatch confirmed)
+- Checkpoint 1.2.2: Tests pass after both fixes applied
+- Checkpoint 1.4: Full regression suite green
+
+### Manual Testing Steps:
+1. Run E2E pipeline test: `npm run test:e2e`
+2. Check email: Form 4 should show "Awarded" (not "Other") for RSU/PSU grants
+3. Check email: Sale transactions should show dollar amounts (not "$0")
+
+## Performance Considerations
+
+None. Changes are:
+- Schema text change (prompt only, no runtime impact)
+- One `.map()` on a 1-5 element array per email render
+
+## Review Notes (2026-03-05)
+
+### Decisions
+| # | Issue | Decision | Rationale |
+|---|-------|----------|-----------|
+| 1 | Normalization placement | Add `price` fallback in `aggregateTransactionsByType` (Step 1.2.3) | Tests call function directly; template mapping alone is insufficient. "Handle more edge cases, not fewer." |
+| 2 | Unused test imports | Remove `isPurchaseTransaction`, `isAwardTransaction`, `isSaleTransaction`, `isGiftTransaction` | Lint compliance — only `aggregateTransactionsByType` is used in tests. |
+| 3 | Type-only fallback tests | Add 2 tests with no `code` field | Insurance against future AI schema regressions where `code` is omitted. |
+| 4 | Performance | No issues | `.map()` on 1-5 elements + 1 `??` fallback per tx — nanoseconds. |
+
+### Critical Finding
+The original plan's totalValue tests would **never have passed** with only the template-level backward-compat mapping. Tests call `aggregateTransactionsByType` directly, bypassing the template's `price` → `pricePerShare` remapping. Step 1.2.3 resolves this by adding a defensive fallback inside the function itself. The template mapping (Step 1.2.2) is retained as belt-and-suspenders for type correctness.
+
+---
+
+## Phase 2: Fix String Transactions + Form 144 Ownership Impact
+
+**Date**: 2026-03-05
+**Context**: E2E testing (Phase 1 manual verification) revealed two additional issues.
+
+### Root Cause Analysis
+
+**Issue 1: AI returns transactions as strings**
+The grok-4.1-fast model outputs `transactions: ["Sold 80 shares at $412 (S, D)", ...]` instead of structured `{code, type, shares, pricePerShare}` objects. When JavaScript spreads a string, it produces `{"0":"S","1":"o",...}` — all fields are undefined, everything classifies as "Other".
+
+**Issue 2: Form 144 lacks ownership impact display**
+COIN's Form 144 email shows "Shares to Sell" and "remaining" but no before/after ownership comparison like Form 4 has. The data fields (`shares`, `remainingHoldings`, `percentOfHoldings`) are already extracted.
+
+### Step 2.1: Parse String Transactions in Normalizer
+
+**File**: `lib/ai/parsers/response-parser.ts` (line 82-100)
+
+In the `case '4'` normalizer, add a guard: if `tx` is a string, parse it into a structured object using the `(CODE, A/D)` pattern at end of string. Otherwise proceed as normal.
+
+AI string patterns:
+```
+"Sold 80 Common Stock shares at $412.460 (S, D)"
+"Exercised into 40,000 Common Stock shares at $14.99 (M, A)"
+"Exercised 40,000 Non-Qualified Stock Option (right to buy) at $0.000 (M, D)"
+```
+
+Parser logic:
+1. Extract `(CODE, A/D)` from parenthetical at end → `code`, `acquisitionDisposition`
+2. Map code to human-readable type (`S`→Sale, `M`→Exercise, `A`→Award, `P`→Purchase, `G`→Gift, etc.)
+3. Extract shares: `([\d,]+)\s*(?:Common Stock\s+)?shares?` or `([\d,]+)\s*Non-Qualified`
+4. Extract price: `\$([\d,.]+)` near "at"
+5. Return structured `{code, type, shares, pricePerShare, acquisitionDisposition}`
+6. If parsing fails, drop the string (let extractor fallback handle it)
+
+### Step 2.2: Template Structural Validation
+
+**File**: `components/ui/email/templates/form4-minimalist-template.tsx` (line ~636)
+
+After mapping `rawTransactions`, filter out items without meaningful fields. If all filtered out, fall through to `extractedTransactions`:
+
+```typescript
+const validTransactions = dataTransactions.filter(t => t.type || t.code || t.shares);
+const transactions = validTransactions.length > 0 ? validTransactions : extractedTransactions;
+```
+
+### Step 2.3: Form 144 Ownership Impact Section
+
+**File**: `components/ui/email/templates/form144-minimalist-template.tsx` (after line 395)
+
+Add "Ownership Impact" section between KEY METRICS and THE STORY:
+- Before: `parseNumericValue(shares) + parseNumericValue(remainingHoldings)` (total before sale)
+- After: `remainingHoldings`
+- Change: calculated percentage reduction
+- Only render when both `shares` AND `remainingHoldings` present
+- Follow Form 4 pattern (lines 908-1002), simplified for sale-only direction
+
+### Step 2.4: Add Regression Tests
+
+**File**: `__tests__/regression/form4-ai-schema-classification.test.ts`
+
+Add tests for:
+- String transactions parsed correctly by normalizer
+- Template structural validation filters invalid items
+- Form 144 ownership calculations
+
+### Step 2.5: Verification
+
+- [x] New + existing regression tests pass (17/17 new, 42/42 existing)
+- [x] Lint clean on changed files
+- [x] Build succeeds
+- [ ] `TEST_TICKERS=TSLA npm run test:e2e` — Form 4 shows correct types (not "Other")
+- [ ] `TEST_TICKERS=COIN npm run test:e2e` — Form 144 shows ownership impact
+- [ ] Check delivered emails visually
+
+## References
+
+- Research: `thoughts/shared/research/2026-03-04-pr356-summary-quality-not-reflected.md`
+- PR #356: commit `91e4fb7`
+- AI schema: `lib/ai/prompts/unified-prompts.ts:313-363`
+- Template: `components/ui/email/templates/form4-minimalist-template.tsx`
+- Merge utils: `lib/email/extractor-merge-utils.ts`
+- Existing regression tests: `__tests__/regression/summary-quality-2026-02-18.test.ts`

--- a/lib/ai/parsers/response-parser.ts
+++ b/lib/ai/parsers/response-parser.ts
@@ -236,7 +236,7 @@ function normalizeFields(data: unknown, filingType: SECFilingType): unknown {
               const code = String(txArr[i].code || '').toUpperCase();
               // Disposition: shares were removed → before = after + shares
               // Acquisition: shares were added → before = after - shares
-              const isDisposition = ad === 'D' || code === 'S' || code === 'G' || code === 'F';
+              const isDisposition = ad === 'D' || code === 'S' || code === 'D' || code === 'G' || code === 'F';
               const previousNum = isDisposition ? sofCleaned + txShares : sofCleaned - txShares;
               if (previousNum > 0) {
                 normalized.previousStake = `${Math.round(previousNum)} shares`;

--- a/lib/ai/parsers/response-parser.ts
+++ b/lib/ai/parsers/response-parser.ts
@@ -16,8 +16,66 @@ import { secLogger as logger } from '../../../utils/logger';
 import { jsonParsingMonitor } from '../../monitoring/json-parsing-monitor';
 
 /**
+ * Transaction code to human-readable type mapping
+ */
+const TX_CODE_TO_TYPE: Record<string, string> = {
+  'P': 'Purchase',
+  'S': 'Sale',
+  'A': 'Award/Grant',
+  'D': 'Disposition',
+  'G': 'Gift',
+  'M': 'Exercise',
+  'F': 'Disposition',
+  'J': 'Transfer',
+  'K': 'Transfer',
+  'X': 'Exercise',
+  'C': 'Exercise',
+  'W': 'Gift',
+};
+
+/**
+ * Parse a string transaction into a structured object.
+ * AI models (especially grok-4.1-fast) sometimes output transactions as strings:
+ *   "Sold 80 Common Stock shares at $412.460 (S, D)"
+ *   "Exercised into 40,000 Common Stock shares at $14.99 (M, A)"
+ *
+ * @param str - Transaction string from AI output
+ * @returns Structured transaction object, or null if unparseable
+ */
+export function parseStringTransaction(str: string): Record<string, string> | null {
+  if (!str || typeof str !== 'string') return null;
+
+  // Extract (CODE, A/D) parenthetical at end of string
+  const codeMatch = str.match(/\(([A-Z]),\s*([AD])\)\s*$/);
+  const code = codeMatch?.[1] || '';
+  const acquisitionDisposition = codeMatch?.[2] || '';
+
+  // Map code to human-readable type
+  const type = code ? (TX_CODE_TO_TYPE[code] || 'Other') : '';
+
+  // Extract share count: look for "N,NNN shares" or "N,NNN [SecurityType]"
+  const sharesMatch = str.match(/([\d,]+(?:\.\d+)?)\s+(?:Common\s+Stock\s+)?(?:shares?|Non-Qualified)/i);
+  const shares = sharesMatch?.[1] || '';
+
+  // Extract price: look for "at $N.NN" or "$N.NN"
+  const priceMatch = str.match(/at\s+\$([\d,.]+)/i) || str.match(/\$([\d,.]+)/);
+  const pricePerShare = priceMatch ? `$${priceMatch[1]}` : '';
+
+  // Must have at least code or shares to be useful
+  if (!code && !shares) return null;
+
+  return {
+    code,
+    type,
+    shares,
+    pricePerShare,
+    acquisitionDisposition,
+  };
+}
+
+/**
  * Normalize fields based on filing type
- * 
+ *
  * @param data - Data to normalize
  * @param filingType - Type of SEC filing
  * @returns Normalized data
@@ -80,9 +138,57 @@ function normalizeFields(data: unknown, filingType: SECFilingType): unknown {
       // Insider trading forms
       if (Array.isArray(normalized.transactions)) {
         normalized.transactions = (normalized.transactions as unknown[]).map((tx: unknown) => {
+          // Handle string transactions: AI sometimes outputs strings like
+          // "Sold 80 shares at $412.460 (S, D)" instead of structured objects
+          if (typeof tx === 'string') {
+            const parsed = parseStringTransaction(tx);
+            if (!parsed) return null; // Drop unparseable strings
+            return parsed;
+          }
           const txObj = tx as Record<string, unknown>;
           const result = { ...txObj };
-          
+
+          // Field-name aliasing: AI models use variant names for the same fields
+          if (!result.code && result.transactionCode) {
+            result.code = result.transactionCode;
+            delete result.transactionCode;
+          }
+          if (!result.type && result.transactionType) {
+            result.type = result.transactionType;
+            delete result.transactionType;
+          }
+          if (!result.pricePerShare && result.price) {
+            result.pricePerShare = result.price;
+          }
+          if (!result.acquisitionDisposition && result.ownershipType) {
+            result.acquisitionDisposition = result.ownershipType;
+            delete result.ownershipType;
+          }
+
+          // Infer code from type when code is missing/empty
+          if ((!result.code || result.code === '') && result.type && typeof result.type === 'string') {
+            const typeStr = (result.type as string).toLowerCase();
+            if (typeStr.includes('sale') || typeStr.includes('sell') || typeStr === 's') result.code = 'S';
+            else if (typeStr.includes('purchase') || typeStr.includes('bought') || typeStr === 'p') result.code = 'P';
+            else if (typeStr.includes('award') || typeStr.includes('grant') || typeStr.includes('rsu')) result.code = 'A';
+            else if (typeStr.includes('gift')) result.code = 'G';
+            else if (typeStr.includes('exercise') || typeStr.includes('conversion')) result.code = 'M';
+            else if (typeStr.includes('disposition') || typeStr.includes('withhold')) result.code = 'D';
+            else if (typeStr.includes('transfer') || typeStr.includes('trust')) result.code = 'J';
+          }
+
+          // Infer type from code when type is missing/empty
+          if ((!result.type || result.type === '') && result.code && typeof result.code === 'string') {
+            result.type = TX_CODE_TO_TYPE[(result.code as string).toUpperCase()] || '';
+          }
+
+          // Strip bracket artifacts from key fields (AI sometimes includes stray [ or ])
+          for (const field of ['code', 'type', 'shares', 'pricePerShare', 'sharesOwnedFollowing']) {
+            if (result[field] && typeof result[field] === 'string') {
+              result[field] = (result[field] as string).replace(/[\[\]]/g, '').trim();
+            }
+          }
+
           // Normalize transaction values
           if (result.price && (typeof result.price === 'string' || typeof result.price === 'number')) {
             result.price = normalizeCurrency(result.price);
@@ -97,9 +203,61 @@ function normalizeFields(data: unknown, filingType: SECFilingType): unknown {
           }
           
           return result;
-        });
+        }).filter(Boolean);
       }
-      
+
+      // Derive newStake from last transaction's sharesOwnedFollowing when not already set
+      if (!normalized.newStake && Array.isArray(normalized.transactions)) {
+        const txArr = normalized.transactions as Record<string, unknown>[];
+        // Use the last transaction's post-transaction ownership as the final stake
+        for (let i = txArr.length - 1; i >= 0; i--) {
+          const sof = txArr[i].sharesOwnedFollowing;
+          if (sof && String(sof).trim()) {
+            const cleaned = String(sof).replace(/[$,\[\]]/g, '').trim();
+            if (/\d/.test(cleaned)) {
+              normalized.newStake = `${cleaned} shares`;
+              break;
+            }
+          }
+        }
+      }
+
+      // Derive previousStake from first transaction's sharesOwnedFollowing + shares
+      if (!normalized.previousStake && normalized.newStake && Array.isArray(normalized.transactions)) {
+        const txArr = normalized.transactions as Record<string, unknown>[];
+        // Find first transaction with sharesOwnedFollowing
+        for (let i = 0; i < txArr.length; i++) {
+          const sof = txArr[i].sharesOwnedFollowing;
+          if (sof && String(sof).trim()) {
+            const sofCleaned = parseFloat(String(sof).replace(/[$,\[\]]/g, '').trim());
+            const txShares = parseFloat(String(txArr[i].shares || '0').replace(/[$,\[\]]/g, '').trim());
+            if (!isNaN(sofCleaned) && !isNaN(txShares) && txShares > 0) {
+              const ad = String(txArr[i].acquisitionDisposition || '').toUpperCase();
+              const code = String(txArr[i].code || '').toUpperCase();
+              // Disposition: shares were removed → before = after + shares
+              // Acquisition: shares were added → before = after - shares
+              const isDisposition = ad === 'D' || code === 'S' || code === 'G' || code === 'F';
+              const previousNum = isDisposition ? sofCleaned + txShares : sofCleaned - txShares;
+              if (previousNum > 0) {
+                normalized.previousStake = `${Math.round(previousNum)} shares`;
+              }
+              break;
+            }
+          }
+        }
+      }
+
+      // Derive percentageChange from previousStake and newStake
+      if (!normalized.percentageChange && normalized.previousStake && normalized.newStake) {
+        const prevNum = parseFloat(String(normalized.previousStake).replace(/[^0-9.]/g, ''));
+        const newNum = parseFloat(String(normalized.newStake).replace(/[^0-9.]/g, ''));
+        if (!isNaN(prevNum) && !isNaN(newNum) && prevNum > 0) {
+          const pctChange = ((newNum - prevNum) / prevNum) * 100;
+          const sign = pctChange >= 0 ? '+' : '';
+          normalized.percentageChange = `${sign}${pctChange.toFixed(1)}%`;
+        }
+      }
+
       // Normalize stake values
       if (normalized.previousStake && typeof normalized.previousStake === 'string') {
         if (/\d/.test(normalized.previousStake)) {

--- a/lib/ai/prompts/unified-prompts.ts
+++ b/lib/ai/prompts/unified-prompts.ts
@@ -331,13 +331,15 @@ export const FORM_SCHEMAS: Record<string, JSONSchema> = {
         items: {
           type: 'object',
           properties: {
-            type: { type: 'string', description: 'Transaction type: A=Acquisition, D=Disposition, P=Purchase, S=Sale, G=Gift, M=Exercise' },
+            code: { type: 'string', description: 'REQUIRED: Raw SEC transaction code letter from Column 3 (e.g., P, S, A, D, G, M, F, J, K, X, C, W). Single uppercase letter exactly as shown in the filing.' },
+            type: { type: 'string', description: 'Human-readable transaction type: Purchase, Sale, Award/Grant, Gift, Exercise, Disposition, Transfer. Use the full word, not the letter code.' },
             shares: { type: 'string', description: 'REQUIRED: Number of shares with commas (from column 5). Never leave blank - extract from table or calculate from value/price.' },
-            price: { type: 'string', description: 'REQUIRED: Price per share with $ from column 4 - if $0, check if this is a gift/grant. Never leave blank.' },
+            pricePerShare: { type: 'string', description: 'REQUIRED: Price per share with $ from column 4 - if $0, check if this is a gift/grant. Never leave blank.' },
             date: { type: 'string', description: 'Transaction date from column 2 (YYYY-MM-DD)' },
-            acquisitionDisposition: { type: 'string', description: 'A for acquired, D for disposed' }
+            acquisitionDisposition: { type: 'string', description: 'A for acquired, D for disposed' },
+            sharesOwnedFollowing: { type: 'string', description: 'Amount of Securities Beneficially Owned Following Reported Transaction from Table I Column 5. Total shares held after this transaction.' }
           },
-          required: ['type', 'shares', 'price']
+          required: ['code', 'type', 'shares', 'pricePerShare', 'sharesOwnedFollowing']
         }
       },
       totalValue: {
@@ -364,7 +366,7 @@ export const FORM_SCHEMAS: Record<string, JSONSchema> = {
 
   '144': {
     type: 'object',
-    required: ['company', 'summary', 'filerName', 'shares', 'estimatedValue', 'remainingHoldings', 'signalStrength'],
+    required: ['company', 'summary', 'filerName', 'shares', 'estimatedValue', 'remainingHoldings', 'signalStrength', 'sharesOutstanding'],
     properties: {
       ...BASE_SCHEMA_PROPERTIES,
       filerName: {
@@ -425,6 +427,11 @@ export const FORM_SCHEMAS: Record<string, JSONSchema> = {
       securityType: {
         type: 'string',
         description: 'Type of securities (e.g., "Common Stock")',
+        maxLength: 50
+      },
+      sharesOutstanding: {
+        type: 'string',
+        description: 'REQUIRED: "Number of Shares or Other Units of the Class Outstanding" - total shares outstanding for the security class (e.g., "3,700,000,000"). Extract from the securitiesInformation section.',
         maxLength: 50
       }
     }
@@ -1025,6 +1032,7 @@ const FORM_EXTRACTION_GUIDANCE: Record<string, string> = {
   * If checkbox marked OR language found = has10b51Plan: true
   * If no checkbox/mention = has10b51Plan: false
 - FOOTNOTES ARE CRITICAL: Often contain essential context about the transaction (vesting schedules, plan details, related transactions)
+- POST-TRANSACTION OWNERSHIP: For each transaction, extract "Amount of Securities Beneficially Owned Following Reported Transaction(s)" (Table I, Column 5) into the sharesOwnedFollowing field. This is the total shares the insider holds AFTER the transaction.
 - The summary MUST include: ticker, insider name, transaction type, SHARE COUNT, dollar amount, and signal assessment`,
 
   '8-K': `8-K EXTRACTION RULES:
@@ -1079,6 +1087,7 @@ const FORM_EXTRACTION_GUIDANCE: Record<string, string> = {
 - CRITICAL: Find the EXACT number of shares proposed for sale - look for "Amount of Securities to be Sold" or similar. Format with commas (e.g., "56,820")
 - Calculate estimated value (shares × approx price per share) and format as "$X.XM" or "$X,XXX,XXX"
 - REQUIRED: Extract "Amount of Securities Beneficially Owned Following Reported Transaction(s)" as remainingHoldings - this is the total shares the filer will STILL OWN after the proposed sale
+- REQUIRED: Extract "Number of Shares or Other Units of the Class Outstanding" as sharesOutstanding - this is the TOTAL shares outstanding for the class (can be billions, e.g., "3,700,000,000" for Tesla). Format with commas.
 - 10b5-1 PLAN REFERENCES: If mentioned, extract plan adoption date - pre-arranged plans are less concerning
 - Check if filing mentions recent related sales by same insider for context (pattern of sales is more significant)
 - The summary MUST lead with: ticker, insider name, shares count, and dollar value
@@ -1265,6 +1274,15 @@ function formatSchemaDescription(schema: JSONSchema): string {
 
     if (prop.type === 'array' && prop.items) {
       lines.push(`  "${key}": [...]${requiredMarker}${constraint} - ${prop.description}`);
+      // Render inner item fields so the AI sees exact field names
+      if (prop.items.type === 'object' && prop.items.properties) {
+        const itemRequiredSet = new Set(prop.items.required || []);
+        lines.push(`    Each item in "${key}" MUST have these fields:`);
+        for (const [itemKey, itemProp] of Object.entries(prop.items.properties)) {
+          const itemRequired = itemRequiredSet.has(itemKey) ? ' (REQUIRED)' : '';
+          lines.push(`      "${itemKey}": "${(itemProp as { type: string }).type}"${itemRequired} - ${(itemProp as { description: string }).description}`);
+        }
+      }
     } else if (prop.type === 'object') {
       lines.push(`  "${key}": {...}${requiredMarker} - ${prop.description}`);
     } else {

--- a/lib/email/form144-data-extractor.ts
+++ b/lib/email/form144-data-extractor.ts
@@ -28,6 +28,7 @@ export interface Form144ExtractedData {
   investorImplication: string;     // Key takeaway for investors
   holdingPeriod: string;           // Time shares have been held (6+ months required)
   volumeLimit: string;             // Rule 144 volume limitations
+  sharesOutstanding: string;       // Number of shares or other units of the class outstanding
 }
 
 /**
@@ -54,6 +55,7 @@ export function extractForm144Data(summaryText: string): Form144ExtractedData {
     investorImplication: '',
     holdingPeriod: '',
     volumeLimit: '',
+    sharesOutstanding: '',
   };
 
   if (!summaryText) {
@@ -98,6 +100,7 @@ export function extractForm144Data(summaryText: string): Form144ExtractedData {
   result.priorThreeMonthSales = extractPriorThreeMonthSales(summaryText);
   result.holdingPeriod = extractHoldingPeriod(summaryText);
   result.volumeLimit = extractVolumeLimit(summaryText);
+  result.sharesOutstanding = extractSharesOutstanding(summaryText);
 
   // Determine signal strength (2-level)
   result.signalStrength = determineSignalStrength(result, summaryText);
@@ -196,8 +199,8 @@ function extractShares(text: string): string {
     if (match?.[1]) {
       const numStr = match[1].replace(/,/g, '');
       const num = parseInt(numStr, 10);
-      // Only accept if it's a reasonable share count (> 0 and not absurdly large like a phone number)
-      if (num > 0 && num < 100000000) {
+      // Only accept if it's a reasonable share count (> 0 and not absurdly large)
+      if (num > 0 && num < 10000000000) {
         return numStr.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
       }
     }
@@ -416,8 +419,58 @@ function extractRemainingHoldings(text: string): string {
     if (match?.[1]) {
       const numStr = match[1].replace(/,/g, '');
       const num = parseInt(numStr, 10);
-      // Sanity check - remaining holdings should be a reasonable number
-      if (num > 0 && num < 1000000000) {
+      // Sanity check - remaining holdings can be very large (e.g., Tesla has 3.7B shares outstanding)
+      if (num > 0 && num < 100000000000) {
+        return numStr.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+      }
+    }
+  }
+
+  return '';
+}
+
+/**
+ * Extract total shares outstanding for the class from summary
+ */
+function extractSharesOutstanding(text: string): string {
+  const patterns = [
+    // "X shares outstanding" or "X shares of the class outstanding"
+    /([\d,]+)\s*(?:shares?|units?)\s*(?:of\s+(?:the\s+)?(?:class\s+)?)?outstanding/i,
+    // "outstanding shares: X"
+    /outstanding\s*(?:shares?|stock)[:\s]*([\d,]+)/i,
+    // "X billion shares outstanding"
+    /([\d.]+)\s*billion\s*shares?\s*outstanding/i,
+    // "X million shares outstanding"
+    /([\d.]+)\s*million\s*shares?\s*outstanding/i,
+    // "total shares outstanding: X"
+    /total\s+shares?\s+outstanding[:\s]*([\d,]+)/i,
+    // "class outstanding: X"
+    /class\s+outstanding[:\s]*([\d,]+)/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    if (match?.[1]) {
+      // Handle "billion" suffix
+      if (text.match(/([\d.]+)\s*billion/i)) {
+        const num = parseFloat(match[1]);
+        if (num > 0 && num < 1000) {
+          const total = Math.round(num * 1000000000);
+          return total.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+        }
+      }
+      // Handle "million" suffix
+      if (text.match(/([\d.]+)\s*million/i) && !match[0].includes(',')) {
+        const num = parseFloat(match[1]);
+        if (num > 0 && num < 1000000) {
+          const total = Math.round(num * 1000000);
+          return total.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+        }
+      }
+      // Regular number
+      const numStr = match[1].replace(/,/g, '');
+      const num = parseInt(numStr, 10);
+      if (num > 0 && num < 100000000000) {
         return numStr.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
       }
     }

--- a/lib/email/form144-data-extractor.ts
+++ b/lib/email/form144-data-extractor.ts
@@ -451,16 +451,16 @@ function extractSharesOutstanding(text: string): string {
   for (const pattern of patterns) {
     const match = text.match(pattern);
     if (match?.[1]) {
-      // Handle "billion" suffix
-      if (text.match(/([\d.]+)\s*billion/i)) {
+      // Handle "billion" suffix — check the matched substring, not full text
+      if (/billion/i.test(match[0])) {
         const num = parseFloat(match[1]);
         if (num > 0 && num < 1000) {
           const total = Math.round(num * 1000000000);
           return total.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
         }
       }
-      // Handle "million" suffix
-      if (text.match(/([\d.]+)\s*million/i) && !match[0].includes(',')) {
+      // Handle "million" suffix — check the matched substring, not full text
+      if (/million/i.test(match[0]) && !match[0].includes(',')) {
         const num = parseFloat(match[1]);
         if (num > 0 && num < 1000000) {
           const total = Math.round(num * 1000000);

--- a/services/filings/form144.ts
+++ b/services/filings/form144.ts
@@ -31,7 +31,9 @@ export const parseForm144 = async (filingDetails: SecFilingDetails): Promise<For
       amountOfSecurities: getNodeText('//ns:sharesAmount'),
       proposedSaleDate: getNodeText('//ns:proposedSaleDate'),
       broker: getNodeText('//ns:brokerName'),
-      note: getNodeText('//ns:remarks') || ''
+      note: getNodeText('//ns:remarks') || '',
+      sharesOutstanding: getNodeText('//ns:noOfUnitsOutstanding') || undefined,
+      aggregateMarketValue: getNodeText('//ns:aggregateMarketValue') || undefined,
     };
   } catch (error) {
     secLogger.error(`Error parsing Form 144: ${error}`);

--- a/services/filings/parsers/form144Parser.ts
+++ b/services/filings/parsers/form144Parser.ts
@@ -57,6 +57,13 @@ export async function parseForm144(filing: {
       const proposedSaleDate = getNodeText('//ns1:proposedSaleDate/text()');
       const broker = getNodeText('//ns1:brokerName/text()');
       const note = getNodeText('//ns1:remarks/text()');
+      // Form 144 XML: securitiesInformation > noOfUnitsOutstanding
+      const sharesOutstanding = getNodeText('//ns1:securitiesInformation/ns1:noOfUnitsOutstanding/text()')
+        || getNodeText('//ns1:noOfUnitsOutstanding/text()')
+        || getNodeText('//noOfUnitsOutstanding/text()');
+      const aggregateMarketValue = getNodeText('//ns1:securitiesInformation/ns1:aggregateMarketValue/text()')
+        || getNodeText('//ns1:aggregateMarketValue/text()')
+        || getNodeText('//aggregateMarketValue/text()');
 
       return {
         reportingPerson,
@@ -66,7 +73,9 @@ export async function parseForm144(filing: {
         amountOfSecurities,
         proposedSaleDate,
         broker,
-        note
+        note,
+        sharesOutstanding: sharesOutstanding || undefined,
+        aggregateMarketValue: aggregateMarketValue || undefined,
       };
     } else {
       // No XML content found, try to extract information from HTML content

--- a/services/form144Service.ts
+++ b/services/form144Service.ts
@@ -39,6 +39,8 @@ interface ParsedFilingContent {
   proposedSaleDate?: string;
   broker?: string;
   note?: string;
+  sharesOutstanding?: string;
+  aggregateMarketValue?: string;
 }
 
 interface FilingDocument {
@@ -103,7 +105,9 @@ export async function parseForm144(filing: ExtendedSecFilingDetails): Promise<Pa
       amountOfSecurities: getElementText('amountOfSecurities'),
       proposedSaleDate: getElementText('proposedSaleDate'),
       broker: getElementText('broker'),
-      note: undefined
+      note: undefined,
+      sharesOutstanding: getElementText('noOfUnitsOutstanding'),
+      aggregateMarketValue: getElementText('aggregateMarketValue'),
     };
 
     return parsedContent;

--- a/types/sec/form144.ts
+++ b/types/sec/form144.ts
@@ -7,4 +7,6 @@ export interface Form144ParsedContent {
   proposedSaleDate: string;
   broker: string;
   note: string;
+  sharesOutstanding?: string;
+  aggregateMarketValue?: string;
 }


### PR DESCRIPTION
## Summary

Fixes Form 4 classification data flow, Form 144 ownership data gaps, and polishes email template visuals across all form types.

## Changes

### Form 4 AI Schema
- Made `sharesOwnedFollowing` required in Form 4 transaction items so AI always extracts post-transaction beneficial ownership

### Form 144 Ownership Data Extraction
- Raised `extractRemainingHoldings` regex cap from 1B→100B (Tesla has 3.7B outstanding shares)
- Raised `extractShares` cap from 100M→10B in `form144-data-extractor.ts`
- Added `noOfUnitsOutstanding` and `aggregateMarketValue` XML extraction to all 3 Form 144 parsers
- Added `sharesOutstanding` as required field in Form 144 AI schema
- Added `extractSharesOutstanding()` text-based fallback in data extractor
- Added `sharesOutstanding`/`aggregateMarketValue` to `Form144ParsedContent` interface

### Form 144 Email Template
- Ownership Impact only shows when insider's actual `remainingHoldings` is available (numeric)
- Removed misleading Case 2 that showed issuer-level `sharesOutstanding` as "ownership impact"
- Filtered out non-numeric `remainingHoldings` values (e.g., "Not disclosed")
- When remaining holdings IS available: shows before→after with percentage

### 8-K Email Template
- Key Highlights bullets changed from inline `<span>` to two-column `<table>` layout
- Wrapped text now aligns with text content, not the bullet character

### Form 4 Email Template
- Minor cleanup for consistency with ownership display patterns

### New Tests
- 40 Form 4 AI schema regression tests (`form4-ai-schema-classification.test.ts`)

## Test Plan
- [x] 79/79 Form 4 classification tests pass
- [x] 40/40 Form 4 AI schema regression tests pass
- [x] E2E tests passing (5/5 - TSLA, VRT, COIN, KO, NVDA)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>