### PR TITLE
Rename Free tier to Trial with expired banner and subscription sync fix

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,73 +1,76 @@
 # Project Progress
 
-**Date**: 2026-03-10
-**Branch**: worktree-summary-enhancements
-**Status**: Summary quality enhancements - Form 144 ownership, Form 4 schema, email template visual fixes
+**Date**: 2026-03-17
+**Branch**: worktree-trial-tier
+**Status**: Stripe Subscription Sync Fix - implementation complete, pending commit
 
 ---
 
 ## Current Session
 
-### Summary Quality Enhancements: Form 144 & Email Templates (2026-03-04 → in progress)
+### Stripe Subscription Sync Fix (2026-03-17)
 
-**Branch**: `worktree-summary-enhancements` | **Plan**: `docs/plans/2026-03-04-fix-form4-classification-data-flow.md`
+**Branch**: `worktree-trial-tier` | **Plan**: `docs/plans/` (inline plan in conversation)
 
-**Goal**: Fix Form 4 classification data flow, Form 144 ownership data gaps, and polish email template visuals across all form types.
+**Problem**: When test user (wilfred.python.test@gmail.com) is deleted and re-onboarded, their DB `User.subscriptionTier` resets to `FREE` (Trial). But their active Stripe subscription still exists — Stripe won't re-fire `checkout.session.completed`, so `syncUserSubscriptionTier()` never fires. Dashboard, billing, and subscribe pages all show "Trial" instead of the paid plan.
 
-**Completed Work**:
+**Root Cause**: `reconcileStripeSubscription()` exists but was gated behind `if (!isNewUser)` in onboarding — re-created users are treated as "new" and skip reconciliation.
 
-**Form 4 AI Schema** ✅ - Made `sharesOwnedFollowing` required in Form 4 transaction items in `unified-prompts.ts`. AI now always extracts post-transaction beneficial ownership.
+**Changes Made**:
 
-**Form 144 Ownership Data Extraction** ✅ - Multi-layer fix:
-- Raised `extractRemainingHoldings` regex cap from 1B→100B (Tesla has 3.7B outstanding)
-- Raised `extractShares` cap from 100M→10B in `form144-data-extractor.ts`
-- Added `noOfUnitsOutstanding` and `aggregateMarketValue` XML extraction to all 3 Form 144 parsers (`form144Parser.ts`, `form144.ts`, `form144Service.ts`)
-- Added `sharesOutstanding` as required field in Form 144 AI schema
-- Added `extractSharesOutstanding()` text-based fallback in data extractor
-- Added `sharesOutstanding`/`aggregateMarketValue` to `Form144ParsedContent` interface
+1. **`app/(auth)/onboarding/actions.ts`** — Removed `!isNewUser` guard from both `completeOnboarding` (~line 262) and `completeOnboardingBatched` (~line 430). Always call `reconcileStripeSubscription()` after user creation/lookup. Also removed now-unused `isNewUser` variable and pre-transaction existence check in batched function.
 
-**Form 144 Email Template** ✅ - `form144-minimalist-template.tsx`:
-- Ownership Impact only shows when insider's actual `remainingHoldings` is available (numeric)
-- Removed misleading Case 2 that showed issuer-level `sharesOutstanding` as "ownership impact" — this is company total class shares, not the insider's position
-- Filtered out non-numeric `remainingHoldings` values (e.g., "Not disclosed") from Shares card
-- When remaining holdings IS available: shows before→↓→after with percentage (matches Form 4 visual)
+2. **`app/api/user/subscription/route.ts`** — Added reconciliation safety net in GET handler. If user has no subscription or has FREE with a `stripeCustomerId`, calls `reconcileStripeSubscription()` and re-fetches. Resolves email from Clerk for Stripe lookup.
 
-**8-K Email Template** ✅ - `8k-minimalist-template.tsx`:
-- Key Highlights bullets changed from inline `<span>` to two-column `<table>` layout
-- Wrapped text now aligns with text content, not the bullet character
+3. **`app/dashboard/page.tsx`** — Added reconciliation on page load for FREE users who have a `UserSubscription` record with `stripeCustomerId`. Avoids unnecessary Stripe API calls for genuinely free users.
 
-**Verification**: All E2E tests passing (5/5 - TSLA, VRT, COIN, KO, NVDA). 79/79 Form 4 classification tests pass. 40/40 Form 4 AI schema regression tests pass.
+**Performance guard**: Only reconcile if user has a `stripeCustomerId` (meaning they've interacted with Stripe before). `reconcileStripeSubscription()` already returns early if user has active paid subscription.
 
-**Files Modified**: `lib/ai/prompts/unified-prompts.ts`, `lib/email/form144-data-extractor.ts`, `types/sec/form144.ts`, `services/filings/parsers/form144Parser.ts`, `services/filings/form144.ts`, `services/form144Service.ts`, `components/ui/email/templates/form144-minimalist-template.tsx`, `components/ui/email/templates/8k-minimalist-template.tsx`, `components/ui/email/templates/form4-minimalist-template.tsx`
-
-**Files Created**: `__tests__/regression/form4-ai-schema-classification.test.ts`, `docs/plans/2026-03-04-fix-form4-classification-data-flow.md`
-
----
-
-## Other Active Worktree
-
-### Onboarding & Tutorial Flow Overhaul (2026-03-02 → in progress)
-
-**Branch**: `worktree-onboarding` | Tasks 1-7 complete, polishing tutorial conditions. See onboarding worktree for full details.
+**Verification**: 7/7 reconciliation unit tests pass. Lint clean. No new type errors.
 
 ---
 
 ## Recently Completed Sessions
 
+### Expired Trial Banner + Free→Trial Rename ✅ (2026-03-13)
+
+**Commits**: `19fd628`, `8b8dd6f`
+
+Added expired trial banner for users past trial period. Renamed "Free" tier to "Trial" across all user-facing surfaces with unlimited tickers during trial.
+
+---
+
+### Summary Quality: Form 144, Form 4 Schema, Email Templates ✅ (2026-03-10)
+
+**PR**: [#361](https://github.com/wilfred-py/tldrsec-ai/pull/361)
+
+Improved Form 144 ownership extraction, Form 4 schema refinements, and email template improvements.
+
+---
+
+### Document PR #356 Analysis + UI Celebration Dependencies ✅ (2026-03-08)
+
+**PR**: [#360](https://github.com/wilfred-py/tldrsec-ai/pull/360)
+
+Documented summary quality analysis from PR #356 and added UI celebration dependencies (confetti, etc.).
+
+---
+
+### Onboarding & Tutorial Flow Overhaul ✅ (2026-03-02 → 2026-03-05)
+
+**PR**: [#358](https://github.com/wilfred-py/tldrsec-ai/pull/358) | **Plan**: `docs/plans/2026-03-02-onboarding-tutorial-flow-overhaul.md`
+
+Overhauled onboarding → tutorial experience: unskippable flow, Clearbit company logos with letter-avatar fallback, SVG spotlight tutorial, cached summary delivery (composite ranking), confetti enhancement, animated transition screen. 7 tasks completed.
+
+**Key files**: `components/onboarding/tutorial-guide.tsx`, `components/ui/company-logo.tsx`, `components/onboarding/onboarding-transition.tsx`, `lib/onboarding/cached-summary-delivery.ts`
+
+---
+
 ### Pipeline Throughput & Worker Cleanup ✅ (2026-03-02)
 
 **PR**: [#357](https://github.com/wilfred-py/tldrsec-ai/pull/357) | **Plan**: `docs/plans/2026-03-02-pipeline-throughput-and-worker-cleanup.md`
 
-**Goal**: Maximize summaries per cron run by looping Step 3 (summarize), removing dead code, and gating verbose logging.
-
-**Phase 1: Dead Code Removal** - Removed `handleIntervalSummary`, `handleSummarizeOnly`, `intervalSummary` health tracking, `USE_ASYNC_PROCESSING` and `RATE_LIMIT_STRATEGY` config vars.
-
-**Phase 2: DEBUG_MODE Logging Gate** - Added `debugLog(env, ...args)` helper, threaded `env` through rate limiting functions, converted 8 verbose logs to debug-only.
-
-**Phase 3: Summarize Loop** - Replaced single Step 3 call with time-budgeted `while` loop (60s buffer, max 10 iterations, fresh HMAC per iteration, breaks on 0 jobs).
-
-**Files**: `cloudflare-cron/index.js`, `cloudflare-cron/wrangler.toml`, `wrangler.toml`, tests updated/created.
-**Verification**: 21 new tests, deployed to Cloudflare (v2.5.0-stable), HMAC verified (HTTP 202).
+Maximized summaries per cron run: dead code removal, DEBUG_MODE logging gate, time-budgeted summarize loop (60s buffer, max 10 iterations). 21 new tests, deployed to Cloudflare (v2.5.0-stable).
 
 ---
 
@@ -83,19 +86,13 @@ Updated free tier pricing card CTA text and removed redundant copy on landing pa
 
 **Root Causes**: (1) POST handler only checked `isActive` in DB, not Stripe source of truth. (2) `userId` mismatch. (3) Upgrades returned 400 instead of modifying existing sub. (4) Downgrade hardcoded `'monthly'`.
 
-**Files**: `lib/stripe/index.ts`, `app/api/webhook/stripe/route.ts`, `app/api/user/subscription/route.ts`, `app/dashboard/page.tsx`, `app/subscribe/page.tsx`, `scripts/cleanup-duplicate-subscriptions.ts`
+**Files**: `lib/stripe/index.ts`, `app/api/webhook/stripe/route.ts`, `app/api/user/subscription/route.ts`, `app/dashboard/page.tsx`, `app/subscribe/page.tsx`
 
 ---
 
 ### Hide Nav Links on Sign-In/Sign-Up Pages ✅ (2026-02-25)
 
 **PR**: [#354](https://github.com/wilfred-py/tldrsec-ai/pull/354)
-
----
-
-### E2E Pipeline Script Alignment with Production Architecture ✅ (2026-02-24)
-
-Rewrote `scripts/test-e2e-email.ts` to use production 3-phase pipeline code paths. Exported `fetchFilingContentOptimized()` from `fetch-handler.ts`.
 
 ---
 
@@ -121,24 +118,6 @@ Phase 1: Expanded Form 4 to 7 classification buckets (78 new tests). Phase 2: Wi
 
 ---
 
-### Tutorial Overlay Bug Fixes ✅ (2026-02-19)
-
-Read `tutorialCompletedAt` from DB, SVG spotlight cutout replacing box-shadow approach, tooltip z-index fix.
-
----
-
-### Dashboard & Auth UX Polish ✅ (2026-02-19)
-
-Dashboard skeleton refinement, sign-up page skeleton with MutationObserver, auth nav cleanup, server-side ticker prefetch (1s load), auth redirect for logged-in users.
-
----
-
-### Worktree Manager + Landing Page Tests ✅ (2026-02-18)
-
-Create-and-open worktree option, 42 auth-aware landing page tests across 5 suites.
-
----
-
 ## Archived Sessions (See TIMELINE.md for Full Details)
 
 For complete technical details of projects older than 30 days, see the weekly archive files in `.claude/history/`:
@@ -150,5 +129,5 @@ For complete technical details of projects older than 30 days, see the weekly ar
 
 ---
 
-*Last Updated: 2026-03-10 (Summary quality enhancements - Form 144 ownership, email template fixes)*
+*Last Updated: 2026-03-17 (Stripe subscription sync fix - worktree-trial-tier)*
 *Completed projects older than 30 days are archived to .claude/history/ - See TIMELINE.md for complete historical context*

--- a/TIMELINE.md
+++ b/TIMELINE.md
@@ -13,8 +13,11 @@
 
 | Date | Project | Status |
 |------|---------|--------|
-| 2026-03-10 | Summary Quality Enhancements: Form 144 Ownership & Email Templates (worktree) | 🔄 In Progress |
-| 2026-03-05 | Onboarding & Tutorial Flow Overhaul (worktree) | 🔄 In Progress |
+| 2026-03-17 | Stripe Subscription Sync Fix (worktree-trial-tier) | 🔄 In Progress |
+| 2026-03-13 | Expired Trial Banner + Free→Trial Rename | ✅ Complete |
+| 2026-03-10 | Summary Quality: Form 144, Form 4 Schema, Email Templates (PR #361) | ✅ Complete |
+| 2026-03-08 | Document PR #356 Analysis + UI Celebration Dependencies (PR #360) | ✅ Complete |
+| 2026-03-05 | Onboarding & Tutorial Flow Overhaul (PR #358) | ✅ Complete |
 | 2026-03-02 | Pipeline Throughput & Worker Cleanup (PR #357) | ✅ Complete |
 | 2026-02-25 | Update Free Tier Pricing Card CTA (PR #355) | ✅ Complete |
 | 2026-02-25 | Hide Nav Links on Sign-In/Sign-Up Pages (PR #354) | ✅ Complete |
@@ -23,10 +26,7 @@
 | 2026-02-24 | Fix Subscription State Not Updating + Dashboard/Subscribe UI (PR #352) | ✅ Complete |
 | 2026-02-20 | Fix Subscribe Page Bugs + Downgrade Support | ✅ Complete |
 | 2026-02-19 | Summary Quality Fixes Phase 2+3: Validation Wrapper + Dedup Guard | ✅ Complete |
-| 2026-02-19 | Tutorial Overlay Bug Fixes | ✅ Complete |
-| 2026-02-19 | Dashboard & Auth UX Polish (skeleton, prefetch, auth redirect) | ✅ Complete |
 | 2026-02-18 | Summary Quality Fixes Phase 1: Form 4 Classification (7 Buckets) | ✅ Complete |
-| 2026-02-18 | Worktree Manager + Landing Page Auth Tests (42 tests) | ✅ Complete |
 
 *These will be archived once they are older than 30 days AND PROGRESS.md exceeds 500 lines*
 
@@ -95,7 +95,7 @@
 
 ## Archive Statistics
 - **Total Archived Projects**: 25
-- **Current PROGRESS.md Lines**: 142
-- **Last Sync**: 2026-03-10
-- **Last Archive Update**: 2026-03-05
+- **Current PROGRESS.md Lines**: 131
+- **Last Sync**: 2026-03-17
+- **Last Archive Update**: 2026-03-17
 - **Archive System**: ✅ ACTIVE

--- a/__tests__/api/three-tier-limits.test.ts
+++ b/__tests__/api/three-tier-limits.test.ts
@@ -39,13 +39,20 @@ describe('3-Tier Limits - FREE, PRO, MAX', () => {
     (getPrismaClient as jest.MockedFunction<typeof getPrismaClient>).mockReturnValue(mockPrisma);
   });
 
-  // Test 1: FREE limit exceeded (EDGE CASE)
-  it('should reject FREE user at 3 ticker limit', async () => {
+  // Test 1: FREE (Trial) tier is now unlimited — should allow any number of tickers
+  it('should allow FREE (Trial) user unlimited tickers', async () => {
     mockPrisma.user.findFirst.mockResolvedValue({
       id: 'user_123',
       email: 'test@example.com',
       subscriptionTier: 'FREE',
-      tickers: new Array(3).fill({ symbol: 'TEST' }) // At limit
+      tickers: new Array(100).fill({ symbol: 'TEST' }) // Many tickers
+    });
+
+    mockPrisma.ticker.findFirst.mockResolvedValue(null); // No existing ticker
+    mockPrisma.ticker.create.mockResolvedValue({
+      id: 'ticker_123',
+      symbol: 'TSLA',
+      companyName: 'Tesla Inc'
     });
 
     const request = new NextRequest('http://localhost/api/user/tickers', {
@@ -54,13 +61,9 @@ describe('3-Tier Limits - FREE, PRO, MAX', () => {
     });
 
     const response = await POST(request);
-    const data = await response.json();
 
-    expect(response.status).toBe(403);
-    expect(data.error).toContain('ticker limit');
-    expect(data.limitReached).toBe(true);
-    expect(data.currentTier).toBe('FREE');
-    expect(data.maxTickers).toBe(3);
+    expect(response.status).toBe(200);
+    expect(mockPrisma.ticker.create).toHaveBeenCalled();
   });
 
   // Test 2: PRO limit exceeded (EDGE CASE) 
@@ -111,11 +114,11 @@ describe('3-Tier Limits - FREE, PRO, MAX', () => {
   });
 
   // Test 4: Under limit success (HAPPY PATH)
-  it('should allow ticker addition when under limit', async () => {
+  it('should allow ticker addition for FREE (unlimited) user', async () => {
     mockPrisma.user.findFirst.mockResolvedValue({
       id: 'user_123',
       subscriptionTier: 'FREE',
-      tickers: new Array(2).fill({ symbol: 'TEST' }) // Under limit
+      tickers: new Array(2).fill({ symbol: 'TEST' })
     });
     
     mockPrisma.ticker.findFirst.mockResolvedValue(null); // No existing ticker

--- a/__tests__/app/dashboard/billing/page.test.tsx
+++ b/__tests__/app/dashboard/billing/page.test.tsx
@@ -19,7 +19,7 @@ const mockBillingPage = () => {
       name: SUBSCRIPTION_PLANS.FREE.name,
       price: '$0/month',
       tickerLimit: SUBSCRIPTION_PLANS.FREE.tickerLimit,
-      tickerDisplay: `${SUBSCRIPTION_PLANS.FREE.tickerLimit} companies`,
+      tickerDisplay: SUBSCRIPTION_PLANS.FREE.tickerLimit === -1 ? 'Unlimited companies' : `${SUBSCRIPTION_PLANS.FREE.tickerLimit} companies`,
       features: SUBSCRIPTION_PLANS.FREE.features,
       recommended: false,
       planKey: 'FREE' as const,
@@ -77,11 +77,11 @@ describe('Billing Page Component', () => {
   });
 
   describe('Pricing Display', () => {
-    it('should display correct Free tier pricing', () => {
+    it('should display correct Trial tier pricing', () => {
       render(mockBillingPage());
-      
+
       expect(screen.getByTestId('price-free')).toHaveTextContent('$0/month');
-      expect(screen.getByTestId('ticker-limit-free')).toHaveTextContent('3 companies');
+      expect(screen.getByTestId('ticker-limit-free')).toHaveTextContent('Unlimited companies');
     });
 
     it('should display correct Pro tier pricing ($199/month)', () => {

--- a/__tests__/app/subscribe/page.test.tsx
+++ b/__tests__/app/subscribe/page.test.tsx
@@ -69,39 +69,41 @@ describe('SubscribePage', () => {
     jest.restoreAllMocks();
   });
 
-  it('should render all three subscription plans', async () => {
+  it('should render only PRO and MAX plans (no FREE card)', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ planType: 'FREE' }),
+      json: () => Promise.resolve({ planType: 'FREE', isTrialing: true, daysRemaining: 5 }),
     });
 
     render(<SubscribePage />);
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /free/i })).toBeInTheDocument();
       expect(screen.getByRole('heading', { name: /pro/i })).toBeInTheDocument();
       expect(screen.getByRole('heading', { name: /max/i })).toBeInTheDocument();
     });
   });
 
-  it('should show disabled CTA for current plan (FREE)', async () => {
+  it('should not show trial banner on subscribe page', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ planType: 'FREE' }),
+      json: () => Promise.resolve({ planType: 'FREE', isActive: true, isTrialing: true, daysRemaining: 5 }),
     });
 
     render(<SubscribePage />);
 
     await waitFor(() => {
-      const currentPlanButton = screen.getByRole('button', { name: /current plan/i });
-      expect(currentPlanButton).toBeDisabled();
+      expect(screen.getByRole('heading', { name: /pro/i })).toBeInTheDocument();
     });
+
+    // Trial banner should not be present on subscribe page
+    expect(screen.queryByText(/days remaining/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Trial Expired/)).not.toBeInTheDocument();
   });
 
-  it('should show upgrade CTAs for non-current plans', async () => {
+  it('should show upgrade CTAs for PRO and MAX plans', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ planType: 'FREE' }),
+      json: () => Promise.resolve({ planType: 'FREE', isTrialing: true, daysRemaining: 5 }),
     });
 
     render(<SubscribePage />);
@@ -122,12 +124,12 @@ describe('SubscribePage', () => {
 
     // Wait for loading to complete
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /free/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /pro/i })).toBeInTheDocument();
     });
 
     await userEvent.keyboard('{Escape}');
 
-    expect(mockBack).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith('/dashboard');
   });
 
   it('should navigate back when back arrow is clicked', async () => {
@@ -139,29 +141,26 @@ describe('SubscribePage', () => {
     render(<SubscribePage />);
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /free/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /pro/i })).toBeInTheDocument();
     });
 
     const backButton = screen.getByRole('button', { name: /go back/i });
     await userEvent.click(backButton);
 
-    expect(mockBack).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith('/dashboard');
   });
 
   it('should show PRO plan as current when user has PRO subscription', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ planType: 'PRO' }),
+      json: () => Promise.resolve({ planType: 'PRO', isActive: true }),
     });
 
     render(<SubscribePage />);
 
     await waitFor(() => {
       // PRO plan should have disabled "Current Plan" button
-      const buttons = screen.getAllByRole('button');
-      const currentPlanButton = buttons.find(btn =>
-        btn.textContent?.toLowerCase().includes('current plan')
-      );
+      const currentPlanButton = screen.getByRole('button', { name: /current plan/i });
       expect(currentPlanButton).toBeDisabled();
 
       // Upgrade to Max should be enabled
@@ -178,7 +177,7 @@ describe('SubscribePage', () => {
     render(<SubscribePage />);
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /free/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /pro/i })).toBeInTheDocument();
     });
 
     // Find the toggle button by its aria-label
@@ -202,7 +201,7 @@ describe('SubscribePage', () => {
     // Should still render page but with error state handling
     await waitFor(() => {
       // Component should handle error gracefully and render plans with default FREE state
-      expect(screen.getByRole('heading', { name: /free/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /pro/i })).toBeInTheDocument();
     });
   });
 

--- a/__tests__/components/dashboard/plan-status-banner.test.tsx
+++ b/__tests__/components/dashboard/plan-status-banner.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+// Mock Next.js Link
+jest.mock('next/link', () => {
+  return ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  );
+});
+
+import { PlanStatusBanner } from '@/components/dashboard/plan-status-banner';
+
+describe('PlanStatusBanner', () => {
+  it('should render trial banner with days remaining', () => {
+    render(
+      <PlanStatusBanner planType="FREE" daysRemaining={5} isTrialing={true} />
+    );
+
+    expect(screen.getByText(/5 days left in your/)).toBeInTheDocument();
+    expect(screen.getByText(/trial/)).toBeInTheDocument();
+    expect(screen.getByText(/Upgrade Now/)).toBeInTheDocument();
+  });
+
+  it('should show singular "day" when 1 day remaining', () => {
+    render(
+      <PlanStatusBanner planType="FREE" daysRemaining={1} isTrialing={true} />
+    );
+
+    expect(screen.getByText(/1 day left in your/)).toBeInTheDocument();
+  });
+
+  it('should not render for PRO users', () => {
+    const { container } = render(
+      <PlanStatusBanner planType="PRO" daysRemaining={5} isTrialing={false} />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should not render for MAX users', () => {
+    const { container } = render(
+      <PlanStatusBanner planType="MAX" daysRemaining={5} isTrialing={false} />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should not render for grandfathered users', () => {
+    const { container } = render(
+      <PlanStatusBanner planType="FREE" daysRemaining={5} isTrialing={true} isGrandfathered={true} />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should show expired banner when trial ended', () => {
+    render(
+      <PlanStatusBanner planType="FREE" daysRemaining={0} isTrialing={false} />
+    );
+
+    expect(screen.getByText(/trial has ended/)).toBeInTheDocument();
+    expect(screen.getByText(/Upgrade Now/)).toBeInTheDocument();
+  });
+
+  it('should always use green for active trials regardless of days remaining', () => {
+    const { container: container1 } = render(
+      <PlanStatusBanner planType="FREE" daysRemaining={1} isTrialing={true} />
+    );
+    expect(container1.firstChild).toHaveClass('bg-emerald-100');
+
+    const { container: container2 } = render(
+      <PlanStatusBanner planType="FREE" daysRemaining={7} isTrialing={true} />
+    );
+    expect(container2.firstChild).toHaveClass('bg-emerald-100');
+  });
+
+  it('should always link to /subscribe', () => {
+    render(
+      <PlanStatusBanner planType="FREE" daysRemaining={5} isTrialing={true} />
+    );
+
+    const link = screen.getByText(/Upgrade Now/).closest('a');
+    expect(link).toHaveAttribute('href', '/subscribe');
+  });
+
+  it('should link to /subscribe for expired trials', () => {
+    render(
+      <PlanStatusBanner planType="FREE" daysRemaining={0} isTrialing={false} />
+    );
+
+    const link = screen.getByText(/Upgrade Now/).closest('a');
+    expect(link).toHaveAttribute('href', '/subscribe');
+  });
+
+  it('should use "trial" not "free trial" in banner text', () => {
+    render(
+      <PlanStatusBanner planType="FREE" daysRemaining={5} isTrialing={true} />
+    );
+
+    const bannerText = screen.getByText(/left in your/);
+    expect(bannerText.textContent).not.toContain('free trial');
+    expect(bannerText.textContent).toContain('trial');
+  });
+});

--- a/__tests__/components/landing/pricing-card.test.tsx
+++ b/__tests__/components/landing/pricing-card.test.tsx
@@ -13,12 +13,12 @@ jest.mock('lucide-react', () => ({
 // Default plan fixture
 const freePlan = {
   key: 'FREE',
-  name: 'Free',
+  name: 'Trial',
   monthlyPrice: 0,
   annualPrice: 0,
-  description: 'Get started with SEC filings',
-  features: ['3 companies to track', 'Real-time email alerts'],
-  cta: 'Get Started',
+  description: 'Full access for 7 days',
+  features: ['**Unlimited** companies', 'Real-time email alerts'],
+  cta: 'Start Free Trial',
   href: '/onboarding',
   popular: false,
   disabled: false,
@@ -59,8 +59,8 @@ describe('PricingCard', () => {
   it('renders plan name, price, and features', () => {
     render(<PricingCard {...defaultProps} />);
 
-    expect(screen.getByRole('heading', { level: 3, name: /Free/i })).toBeInTheDocument();
-    expect(screen.getByText('3 companies to track')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3, name: /Trial/i })).toBeInTheDocument();
+    expect(screen.getByText('Unlimited')).toBeInTheDocument();
     expect(screen.getByText('Real-time email alerts')).toBeInTheDocument();
   });
 
@@ -160,9 +160,9 @@ describe('PricingCard', () => {
     expect(strongElement.tagName).toBe('STRONG');
   });
 
-  it('shows "Everything in Free" footer for PRO plan', () => {
+  it('shows "Everything in Trial" footer for PRO plan', () => {
     render(<PricingCard {...defaultProps} plan={proPlan} />);
 
-    expect(screen.getByText('Everything in Free')).toBeInTheDocument();
+    expect(screen.getByText('Everything in Trial')).toBeInTheDocument();
   });
 });

--- a/__tests__/components/landing/pricing-section-v2.test.tsx
+++ b/__tests__/components/landing/pricing-section-v2.test.tsx
@@ -54,14 +54,14 @@ describe('PricingSectionV2', () => {
     render(<PricingSectionV2 />);
     const tierHeadings = screen.getAllByRole('heading', { level: 3 });
     const tierNames = tierHeadings.map((h) => h.textContent);
-    expect(tierNames).toContain('Free');
+    expect(tierNames).toContain('Trial');
     expect(tierNames).toContain('Pro');
     expect(tierNames).toContain('Max');
   });
 
   it('should display prices for all tiers', () => {
     render(<PricingSectionV2 />);
-    // Free tier shows "Free"
+    // Trial tier shows "Free" price text
     expect(screen.getByText('Free', { selector: 'span' })).toBeInTheDocument();
     // PRO tier shows $199
     expect(screen.getByText('$199')).toBeInTheDocument();
@@ -93,10 +93,10 @@ describe('PricingSectionV2', () => {
 
   it('should display feature lists for each tier', () => {
     render(<PricingSectionV2 />);
-    expect(screen.getByText(/3 companies/i)).toBeInTheDocument();
+    // Trial tier now shows unlimited companies
+    expect(screen.getAllByText(/Unlimited/i).length).toBeGreaterThanOrEqual(2); // Trial + Max both have unlimited
     // PRO: "25" in bold (rendered within <strong>)
     expect(screen.getByText('25')).toBeInTheDocument();
-    expect(screen.getByText(/Unlimited/i)).toBeInTheDocument();
   });
 
   it('should have CTA buttons for each tier (unauthenticated shows "Get Started")', () => {

--- a/__tests__/components/pricing-section-3-tier.test.tsx
+++ b/__tests__/components/pricing-section-3-tier.test.tsx
@@ -18,7 +18,7 @@ describe('PricingSection3Tier - FREE + PRO + MAX', () => {
     expect(screen.getByText('MAX')).toBeInTheDocument();
     expect(screen.getByText('$199')).toBeInTheDocument();
     expect(screen.getByText('$349')).toBeInTheDocument();
-    expect(screen.getByText('3 companies to track')).toBeInTheDocument();
+    expect(screen.getByText('Unlimited companies to track')).toBeInTheDocument();
     expect(screen.getByText('25 companies to track')).toBeInTheDocument();
     expect(screen.getByText('Unlimited companies')).toBeInTheDocument();
   });
@@ -90,7 +90,7 @@ describe('PricingSection3Tier - FREE + PRO + MAX', () => {
     render(<PricingSection3Tier />);
     
     fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'test@example.com' } });
-    fireEvent.click(screen.getByText('Start FREE Trial'));
+    fireEvent.click(screen.getByText('Start Trial'));
 
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledWith('/api/checkout/direct', {

--- a/__tests__/components/settings/user-profile-section.test.tsx
+++ b/__tests__/components/settings/user-profile-section.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+// Mock sonner toast
+jest.mock('sonner', () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+import UserProfileSection from '@/components/settings/UserProfileSection';
+
+const mockUser = {
+  id: 'test-user-id',
+  firstName: 'Test',
+  lastName: 'User',
+  emailAddresses: [{ emailAddress: 'test@example.com' }],
+  createdAt: new Date('2025-01-01').getTime(),
+} as any;
+
+describe('UserProfileSection', () => {
+  it('should display "Trial" not "Free Plan" in subscription section', () => {
+    render(<UserProfileSection user={mockUser} />);
+
+    expect(screen.getByText('Trial')).toBeInTheDocument();
+    expect(screen.queryByText('Free Plan')).not.toBeInTheDocument();
+    expect(screen.queryByText('Free')).not.toBeInTheDocument();
+  });
+
+  it('should render user profile information', () => {
+    render(<UserProfileSection user={mockUser} />);
+
+    expect(screen.getByDisplayValue('Test User')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('test@example.com')).toBeInTheDocument();
+  });
+
+  it('should show subscription section with upgrade button', () => {
+    render(<UserProfileSection user={mockUser} />);
+
+    expect(screen.getByText('Subscription')).toBeInTheDocument();
+    expect(screen.getByText('Upgrade to Pro')).toBeInTheDocument();
+    expect(screen.getByText('View Plans')).toBeInTheDocument();
+  });
+});

--- a/__tests__/config/stripe-pricing.test.ts
+++ b/__tests__/config/stripe-pricing.test.ts
@@ -1,12 +1,17 @@
 import { SUBSCRIPTION_PLANS, getPlanConfig, calculateSavingsPercentage } from '@/lib/stripe';
 
 describe('Stripe Pricing Configuration', () => {
-  describe('Free Tier', () => {
-    it('should have $0 price and 3 ticker limit', () => {
+  describe('Free (Trial) Tier', () => {
+    it('should have $0 price and unlimited ticker limit', () => {
       const plan = getPlanConfig('FREE');
       expect(plan).toBeDefined();
       expect(plan?.monthlyPrice).toBe(0);
-      expect(plan?.tickerLimit).toBe(3);
+      expect(plan?.tickerLimit).toBe(-1);
+    });
+
+    it('should be named Trial', () => {
+      const plan = getPlanConfig('FREE');
+      expect(plan?.name).toBe('Trial');
     });
   });
 
@@ -108,9 +113,9 @@ describe('Stripe Pricing Configuration', () => {
   });
 
   describe('Plan Features', () => {
-    it('Free tier should have limited filing types', () => {
+    it('Free (Trial) tier should have ALL filing types', () => {
       const plan = getPlanConfig('FREE');
-      expect(plan?.filingTypes).toEqual(['10-K', '10-Q']);
+      expect(plan?.filingTypes).toEqual(['ALL']);
     });
 
     it('Pro tier should have ALL filing types at $199 tier', () => {
@@ -135,9 +140,9 @@ describe('Stripe Pricing Configuration', () => {
   });
 
   describe('Email Frequency', () => {
-    it('Free tier should have weekly email frequency', () => {
+    it('Free (Trial) tier should have realtime email frequency', () => {
       const plan = getPlanConfig('FREE');
-      expect(plan?.emailFrequency).toBe('weekly');
+      expect(plan?.emailFrequency).toBe('realtime');
     });
 
     it('Pro tier should have realtime email frequency', () => {

--- a/__tests__/e2e/pricing-max-tier.test.ts
+++ b/__tests__/e2e/pricing-max-tier.test.ts
@@ -16,16 +16,16 @@ describe('E2E: Pricing Page with Max Tier', () => {
   });
 
   describe('Pricing Page Display', () => {
-    it('should display three tiers: Free, Pro, and Max', async () => {
+    it('should display three tiers: Trial, Pro, and Max', async () => {
       await page.goto(`${baseUrl}/pricing`);
       await page.waitForLoadState('networkidle');
 
       // Check for tier names
-      const freeTier = await page.locator('text=Free').first();
+      const trialTier = await page.locator('text=Trial').first();
       const proTier = await page.locator('text=Pro').first();
       const maxTier = await page.locator('text=Max').first();
 
-      expect(await freeTier.isVisible()).toBe(true);
+      expect(await trialTier.isVisible()).toBe(true);
       expect(await proTier.isVisible()).toBe(true);
       expect(await maxTier.isVisible()).toBe(true);
     });

--- a/__tests__/integration/direct-checkout-flow.test.ts
+++ b/__tests__/integration/direct-checkout-flow.test.ts
@@ -51,7 +51,7 @@ jest.mock('@/lib/stripe', () => ({
     },
   },
   SUBSCRIPTION_PLANS: {
-    FREE: { name: 'Free', monthlyPriceId: null, monthlyPrice: 0, tickerLimit: 3 },
+    FREE: { name: 'Trial', monthlyPriceId: null, monthlyPrice: 0, tickerLimit: -1 },
     PRO: { name: 'Pro', monthlyPriceId: 'price_pro_monthly', monthlyPrice: 2900, tickerLimit: 25 },
     MAX: { name: 'Max', monthlyPriceId: 'price_max_monthly', monthlyPrice: 9900, tickerLimit: -1 },
   },

--- a/app/(auth)/onboarding/actions.ts
+++ b/app/(auth)/onboarding/actions.ts
@@ -178,7 +178,6 @@ export async function completeOnboarding(): Promise<{ success: boolean; error?: 
     const userName = user.firstName ? `${user.firstName} ${user.lastName || ''}`.trim() : 'User';
     
     // Check if user exists in database by both authProviderId and email
-    // R7: Also used to determine isNewUser for reconciliation guard
     let dbUser = await getPrismaClient().user.findFirst({
       where: {
         OR: [
@@ -187,7 +186,6 @@ export async function completeOnboarding(): Promise<{ success: boolean; error?: 
         ]
       }
     });
-    const isNewUser = !dbUser;
 
     // If user doesn't exist yet, create a new user record
     if (!dbUser) {
@@ -258,8 +256,8 @@ export async function completeOnboarding(): Promise<{ success: boolean; error?: 
     }
 
     // Reconcile Stripe subscription (fire-and-forget)
-    // Only for pre-existing users (skip freshly-created users)
-    if (!isNewUser && dbUser) {
+    // Always attempt — handles re-onboarded users whose Stripe sub still exists
+    if (dbUser) {
       import('@/lib/stripe/reconcile')
         .then(({ reconcileStripeSubscription }) =>
           reconcileStripeSubscription(dbUser.id, primaryEmail)
@@ -326,13 +324,6 @@ export async function completeOnboardingBatched(input: {
       : 'User';
 
     console.log(`[Onboarding] Starting batched completion for ${primaryEmail}`);
-
-    // R7: Pre-transaction check for user existence (for reconciliation guard)
-    const existingUser = await getPrismaClient().user.findFirst({
-      where: { OR: [{ authProviderId: userId }, { email: primaryEmail }] },
-      select: { id: true },
-    });
-    const isNewUser = !existingUser;
 
     // Convert preferences to plain JSON object
     const preferencesJson = JSON.parse(JSON.stringify(input.preferences));
@@ -425,9 +416,9 @@ export async function completeOnboardingBatched(input: {
       console.error('[Onboarding] Failed to queue welcome email:', err);
     });
 
-    // Reconcile Stripe subscription (Issue 15: fire-and-forget)
-    // Only for pre-existing users (Issue 6: skip freshly-created users)
-    if (!isNewUser) {
+    // Reconcile Stripe subscription (fire-and-forget)
+    // Always attempt — handles re-onboarded users whose Stripe sub still exists
+    {
       import('@/lib/stripe/reconcile')
         .then(({ reconcileStripeSubscription }) =>
           reconcileStripeSubscription(result.id, primaryEmail)

--- a/app/(auth)/onboarding/actions.ts
+++ b/app/(auth)/onboarding/actions.ts
@@ -418,20 +418,18 @@ export async function completeOnboardingBatched(input: {
 
     // Reconcile Stripe subscription (fire-and-forget)
     // Always attempt — handles re-onboarded users whose Stripe sub still exists
-    {
-      import('@/lib/stripe/reconcile')
-        .then(({ reconcileStripeSubscription }) =>
-          reconcileStripeSubscription(result.id, primaryEmail)
-        )
-        .then((reconcileResult) => {
-          if (reconcileResult.reconciled) {
-            console.log(`[Onboarding] Reconciled Stripe subscription: ${reconcileResult.planType}`);
-          }
-        })
-        .catch((reconcileError) => {
-          console.error('[Onboarding] Stripe reconciliation failed:', reconcileError);
-        });
-    }
+    import('@/lib/stripe/reconcile')
+      .then(({ reconcileStripeSubscription }) =>
+        reconcileStripeSubscription(result.id, primaryEmail)
+      )
+      .then((reconcileResult) => {
+        if (reconcileResult.reconciled) {
+          console.log(`[Onboarding] Reconciled Stripe subscription: ${reconcileResult.planType}`);
+        }
+      })
+      .catch((reconcileError) => {
+        console.error('[Onboarding] Stripe reconciliation failed:', reconcileError);
+      });
 
     const totalTime = Date.now() - startTime;
     console.log(`[Onboarding] Completed in ${totalTime}ms`);

--- a/app/(auth)/onboarding/onboarding-client.tsx
+++ b/app/(auth)/onboarding/onboarding-client.tsx
@@ -23,7 +23,10 @@ import { THREE_TIER_LIMITS } from "@/lib/subscription/three-tier-limits";
 import { CompanyLogo } from "@/components/ui/company-logo";
 import { OnboardingTransition } from "@/components/onboarding/onboarding-transition";
 
-const MAX_TICKERS = THREE_TIER_LIMITS.FREE; // 3
+const TIER_LIMIT = THREE_TIER_LIMITS.FREE;
+const isUnlimited = TIER_LIMIT === -1;
+const ONBOARDING_SOFT_CAP = 15; // Soft cap for onboarding picker UI only
+const MAX_TICKERS = isUnlimited ? ONBOARDING_SOFT_CAP : TIER_LIMIT;
 
 // Define sectors with their icons and descriptions
 const sectors = [
@@ -510,7 +513,10 @@ export default function OnboardingPage() {
                     <div className="text-center mb-6">
                       <h2 className="text-xl font-bold">Choose your first companies</h2>
                       <p className="text-muted-foreground">
-                        Select up to {MAX_TICKERS} tickers to start tracking. Based on your selected sectors.
+                        {isUnlimited
+                          ? 'Select the companies you want to track. Based on your selected sectors.'
+                          : `Select up to ${MAX_TICKERS} tickers to start tracking. Based on your selected sectors.`
+                        }
                       </p>
                     </div>
 
@@ -599,7 +605,10 @@ export default function OnboardingPage() {
                       </Button>
                       <div className="flex items-center gap-4">
                         <span className="text-sm text-muted-foreground">
-                          {selectedEquities.length} of {MAX_TICKERS} tickers selected
+                          {isUnlimited
+                            ? `${selectedEquities.length} tickers selected`
+                            : `${selectedEquities.length} of ${MAX_TICKERS} tickers selected`
+                          }
                         </span>
                         <Button onClick={handleNext} disabled={selectedEquities.length === 0 || isSubmitting}>
                           {isSubmitting ? (

--- a/app/api/user/subscription/route.ts
+++ b/app/api/user/subscription/route.ts
@@ -191,7 +191,7 @@ export async function POST(request: NextRequest) {
       // FREE tier doesn't need checkout
       if (planType === 'FREE') {
         return NextResponse.json(
-          { error: 'Free tier does not require checkout' },
+          { error: 'Trial tier does not require checkout' },
           { status: 400 }
         );
       }
@@ -522,7 +522,7 @@ export async function PUT(request: NextRequest) {
           cancelAtPeriodEnd: updated.cancelAtPeriodEnd,
           stripeCustomerId: updated.stripeCustomerId,
           stripeSubscriptionId: updated.stripeSubscriptionId,
-          message: 'Subscription will be downgraded to Free at the end of the billing period',
+          message: 'Subscription will be downgraded to Trial at the end of the billing period',
         });
       }
 

--- a/app/api/user/subscription/route.ts
+++ b/app/api/user/subscription/route.ts
@@ -71,9 +71,34 @@ export async function GET() {
     }
 
     // Get user's subscription from database using resolved DB user ID
-    const userSubscription = await prisma.userSubscription.findUnique({
+    let userSubscription = await prisma.userSubscription.findUnique({
       where: { userId },
     });
+
+    // Safety net: if no subscription or FREE with a stripeCustomerId, reconcile from Stripe
+    if (
+      (!userSubscription || (userSubscription.planType === 'FREE' && userSubscription.stripeCustomerId)) &&
+      isStripeEnabled()
+    ) {
+      try {
+        // Resolve email for Stripe lookup
+        const clerkUser = await currentUser();
+        const email = clerkUser?.emailAddresses?.[0]?.emailAddress;
+        if (email) {
+          const { reconcileStripeSubscription } = await import('@/lib/stripe/reconcile');
+          const result = await reconcileStripeSubscription(userId, email);
+          if (result.reconciled) {
+            console.log(`[subscription GET] Reconciled Stripe subscription: ${result.planType}`);
+            // Re-fetch after reconciliation
+            userSubscription = await prisma.userSubscription.findUnique({
+              where: { userId },
+            });
+          }
+        }
+      } catch (reconcileError) {
+        console.error('[subscription GET] Reconciliation failed:', reconcileError);
+      }
+    }
 
     if (!userSubscription) {
       // Return default free tier info if no subscription exists

--- a/app/dashboard/billing/page.tsx
+++ b/app/dashboard/billing/page.tsx
@@ -24,16 +24,8 @@ import {
 import { toast } from 'sonner';
 import { format } from 'date-fns';
 import { useUser } from '@clerk/nextjs';
-import { SUBSCRIPTION_PLANS, type PlanType } from '@/lib/stripe/plans';
-
-interface UserSubscription {
-  planType: PlanType;
-  isActive: boolean;
-  currentPeriodEnd: string;
-  cancelAtPeriodEnd: boolean;
-  stripeCustomerId?: string;
-  stripeSubscriptionId?: string;
-}
+import { SUBSCRIPTION_PLANS } from '@/lib/stripe/plans';
+import type { UserSubscription } from '@/lib/types/subscription';
 
 export default function BillingPage() {
   const { user } = useUser();
@@ -148,8 +140,17 @@ export default function BillingPage() {
   const currentPlanKey = subscription?.planType;
   const currentPlanConfig = currentPlanKey ? SUBSCRIPTION_PLANS[currentPlanKey] : null;
   const isFree = currentPlanKey === 'FREE';
+
+  const getTrialStatusText = () => {
+    if (!subscription || !isFree) return null;
+    if (subscription.isTrialing && subscription.daysRemaining > 0) {
+      return `Trial — ${subscription.daysRemaining} ${subscription.daysRemaining === 1 ? 'day' : 'days'} remaining`;
+    }
+    return 'Trial Expired — Upgrade to continue receiving summaries';
+  };
+
   const currentPrice = isFree
-    ? '$0/month'
+    ? (getTrialStatusText() || 'Trial')
     : currentPlanConfig
       ? `$${currentPlanConfig.monthlyPrice}/month`
       : 'Price unavailable';
@@ -197,7 +198,7 @@ export default function BillingPage() {
           <CardContent className="space-y-4">
             <div>
               <h3 className="font-semibold text-lg">
-                {currentPlanConfig?.name || 'Unknown Plan'}
+                {isFree ? 'Trial' : (currentPlanConfig?.name || 'Unknown Plan')}
               </h3>
               <p className="text-gray-600">
                 {currentPrice}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -48,6 +48,31 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
       if (dbUser) {
         tutorialCompleted = dbUser.tutorialCompletedAt != null;
         subscriptionTier = (dbUser.subscriptionTier as 'FREE' | 'PRO' | 'MAX') || 'FREE';
+
+        // Safety net: reconcile Stripe subscription for FREE users who have interacted with Stripe
+        if (subscriptionTier === 'FREE' && email) {
+          try {
+            // Only reconcile if user has a UserSubscription with stripeCustomerId
+            const existingSub = await prisma.userSubscription.findUnique({
+              where: { userId: dbUser.id },
+              select: { stripeCustomerId: true, planType: true },
+            });
+            if (existingSub?.stripeCustomerId && existingSub.planType === 'FREE') {
+              const { isStripeEnabled } = await import('@/lib/stripe');
+              if (isStripeEnabled()) {
+                const { reconcileStripeSubscription } = await import('@/lib/stripe/reconcile');
+                const result = await reconcileStripeSubscription(dbUser.id, email);
+                if (result.reconciled && result.planType) {
+                  subscriptionTier = result.planType as 'FREE' | 'PRO' | 'MAX';
+                  console.log(`[dashboard] Reconciled Stripe subscription: ${result.planType}`);
+                }
+              }
+            }
+          } catch (reconcileError) {
+            console.error('[dashboard] Stripe reconciliation failed:', reconcileError);
+          }
+        }
+
         initialCompanies = dbUser.tickers.map(ticker => ({
           id: ticker.id,
           symbol: ticker.symbol,

--- a/app/subscribe/page.tsx
+++ b/app/subscribe/page.tsx
@@ -24,11 +24,7 @@ import {
   type BillingInterval,
 } from '@/lib/stripe/plans';
 import { AnimatedPrice, StaticPrice } from '@/components/landing/sections-v2/animated-price';
-
-interface UserSubscription {
-  planType: PlanType;
-  isActive: boolean;
-}
+import type { UserSubscription } from '@/lib/types/subscription';
 
 const PLAN_ICONS: Record<PlanType, typeof Sparkles | null> = {
   FREE: null,
@@ -36,7 +32,7 @@ const PLAN_ICONS: Record<PlanType, typeof Sparkles | null> = {
   MAX: Crown,
 };
 
-const PLAN_ORDER: PlanType[] = ['FREE', 'PRO', 'MAX'];
+const PLAN_ORDER: PlanType[] = ['PRO', 'MAX'];
 const PLAN_RANK: Record<PlanType, number> = { FREE: 0, PRO: 1, MAX: 2 };
 
 function SubscribePageContent() {
@@ -216,10 +212,9 @@ function SubscribePageContent() {
     return subscription.planType;
   };
 
-  const getButtonType = (planKey: PlanType): 'current' | 'upgrade' | 'downgrade' | 'free' => {
+  const getButtonType = (planKey: PlanType): 'current' | 'upgrade' | 'downgrade' => {
     const effectivePlan = getEffectivePlan();
     if (planKey === effectivePlan) return 'current';
-    if (!subscription && planKey === 'FREE') return 'free';
     if (PLAN_RANK[planKey] > PLAN_RANK[effectivePlan]) return 'upgrade';
     return 'downgrade';
   };
@@ -276,8 +271,8 @@ function SubscribePageContent() {
             <Skeleton className="h-4 w-36" />
             <Skeleton className="h-6 w-12 rounded-full" />
           </div>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            {Array.from({ length: 3 }).map((_, i) => (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {Array.from({ length: 2 }).map((_, i) => (
               <div key={i} className="rounded-xl border p-6 space-y-4 animate-slideUp" style={{ animationDelay: `${i * 100}ms`, backgroundColor: 'var(--landing-card-bg, white)' }}>
                 <div className="flex items-center justify-between">
                   <div className="space-y-1"><Skeleton className="h-3 w-12" /><Skeleton className="h-7 w-24" /></div>
@@ -351,7 +346,7 @@ function SubscribePageContent() {
         </motion.div>
 
         {/* Plan Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           {PLAN_ORDER.map((planKey, index) => {
             const plan = SUBSCRIPTION_PLANS[planKey];
             const Icon = PLAN_ICONS[planKey];
@@ -380,7 +375,7 @@ function SubscribePageContent() {
                 <div className="flex items-center justify-between mb-4">
                   <div>
                     <p className="text-xs text-[var(--landing-text-muted)] uppercase tracking-wide mb-1">
-                      {planKey === 'FREE' ? 'Basic' : plan.name}
+                      {plan.name}
                     </p>
                     <h3 className="text-2xl font-bold" style={{ color: 'var(--landing-secondary)' }}>
                       {plan.name}
@@ -433,16 +428,6 @@ function SubscribePageContent() {
                             className="w-full bg-gray-100 text-gray-500 cursor-not-allowed"
                           >
                             Current Plan
-                          </Button>
-                        );
-                      case 'free':
-                        return (
-                          <Button
-                            variant="outline"
-                            disabled
-                            className="w-full"
-                          >
-                            Free Tier
                           </Button>
                         );
                       case 'downgrade':
@@ -510,12 +495,12 @@ function SubscribePageContent() {
                   })}
                 </ul>
 
-                {/* Everything in X footer */}
-                {planKey !== 'FREE' && (
+                {/* Everything in Pro footer (MAX only) */}
+                {planKey === 'MAX' && (
                   <div className="mt-4 pt-4 border-t border-gray-100">
                     <div className="flex items-center gap-2 text-sm text-[var(--landing-text-muted)]">
                       <span className="text-[var(--landing-primary)]">+</span>
-                      <span>Everything in {planKey === 'PRO' ? 'Free' : 'Pro'}</span>
+                      <span>Everything in Pro</span>
                     </div>
                   </div>
                 )}
@@ -590,8 +575,8 @@ function SubscribePageLoading() {
           <Skeleton className="h-4 w-36" />
           <Skeleton className="h-6 w-12 rounded-full" />
         </div>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          {Array.from({ length: 3 }).map((_, i) => (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {Array.from({ length: 2 }).map((_, i) => (
             <div key={i} className="rounded-xl border p-6 space-y-4 animate-slideUp" style={{ animationDelay: `${i * 100}ms`, backgroundColor: 'var(--landing-card-bg, white)' }}>
               <div className="flex items-center justify-between">
                 <div className="space-y-1"><Skeleton className="h-3 w-12" /><Skeleton className="h-7 w-24" /></div>

--- a/components/dashboard/dashboard-shell.tsx
+++ b/components/dashboard/dashboard-shell.tsx
@@ -19,7 +19,6 @@ export function DashboardShell({ children }: DashboardShellProps) {
         <ErrorHandler />
       </Suspense>
       <div className="min-h-screen flex flex-col" style={{ backgroundColor: 'var(--landing-bg)' }}>
-        <MinimalHeader />
         {subscription && (
           <PlanStatusBanner
             planType={subscription.planType as "FREE" | "PRO" | "MAX"}
@@ -28,6 +27,7 @@ export function DashboardShell({ children }: DashboardShellProps) {
             isGrandfathered={subscription.isGrandfathered}
           />
         )}
+        <MinimalHeader />
         <main className="flex-1" style={{ backgroundColor: 'var(--landing-bg)' }}>
           <div className="container max-w-7xl mx-auto py-8 md:py-10 px-6 md:px-8 space-y-8">
             {children}

--- a/components/dashboard/plan-status-banner.tsx
+++ b/components/dashboard/plan-status-banner.tsx
@@ -18,55 +18,53 @@ export function PlanStatusBanner({
   isTrialing,
   isGrandfathered,
 }: PlanStatusBannerProps) {
-  // Only show banner for active trial users
-  if (planType !== 'FREE' || !isTrialing || isGrandfathered) return null;
-  if (daysRemaining === undefined || daysRemaining <= 0) return null;
+  // Only show banner for FREE-tier users who are not grandfathered
+  if (planType !== 'FREE' || isGrandfathered) return null;
 
-  const getUrgencyConfig = () => {
-    if (daysRemaining <= 2) {
-      return {
-        bgColor: 'bg-red-100 dark:bg-red-950/30',
-        borderColor: 'border-red-200 dark:border-red-900',
-        textColor: 'text-red-900 dark:text-red-100',
-        buttonColor: 'bg-red-600 hover:bg-red-700',
-      };
-    } else if (daysRemaining <= 5) {
-      return {
-        bgColor: 'bg-orange-100 dark:bg-orange-950/30',
-        borderColor: 'border-orange-200 dark:border-orange-900',
-        textColor: 'text-orange-900 dark:text-orange-100',
-        buttonColor: 'bg-orange-600 hover:bg-orange-700',
-      };
-    } else {
-      return {
-        bgColor: 'bg-emerald-100 dark:bg-emerald-950/30',
-        borderColor: 'border-emerald-200 dark:border-emerald-900',
-        textColor: 'text-emerald-900 dark:text-emerald-100',
-        buttonColor: 'bg-emerald-600 hover:bg-emerald-700',
-      };
-    }
-  };
+  const isExpired = !isTrialing || daysRemaining === undefined || daysRemaining <= 0;
 
-  const config = getUrgencyConfig();
+  if (isExpired) {
+    return (
+      <div className={cn('w-full border-b', 'bg-red-100 dark:bg-red-950/30', 'border-red-200 dark:border-red-900')}>
+        <div className="container max-w-7xl mx-auto px-6 md:px-8 py-3">
+          <div className="flex items-center justify-center gap-4">
+            <span className="text-sm font-medium text-red-900 dark:text-red-100">
+              Your trial has ended &mdash; upgrade now to continue receiving summaries
+            </span>
+            <Button
+              size="sm"
+              asChild
+              className="text-white font-medium shadow-sm bg-red-600 hover:bg-red-700"
+            >
+              <Link
+                href="/subscribe"
+                className="flex items-center gap-2"
+              >
+                <CreditCard className="h-4 w-4" />
+                Upgrade Now
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <div className={cn('w-full border-b', config.bgColor, config.borderColor)}>
+    <div className={cn('w-full border-b', 'bg-emerald-100 dark:bg-emerald-950/30', 'border-emerald-200 dark:border-emerald-900')}>
       <div className="container max-w-7xl mx-auto px-6 md:px-8 py-3">
         <div className="flex items-center justify-center gap-4">
-          <span className={cn('text-sm font-medium', config.textColor)}>
+          <span className="text-sm font-medium text-emerald-900 dark:text-emerald-100">
             {daysRemaining} {daysRemaining === 1 ? 'day' : 'days'} left in your
-            free trial
+            trial
           </span>
           <Button
             size="sm"
             asChild
-            className={cn(
-              'text-white font-medium shadow-sm',
-              config.buttonColor
-            )}
+            className="text-white font-medium shadow-sm bg-emerald-600 hover:bg-emerald-700"
           >
             <Link
-              href="/dashboard/billing"
+              href="/subscribe"
               className="flex items-center gap-2"
             >
               <CreditCard className="h-4 w-4" />

--- a/components/landing/pricing-card.tsx
+++ b/components/landing/pricing-card.tsx
@@ -63,7 +63,7 @@ export function PricingCard({
       <div className="flex items-center justify-between mb-4">
         <div>
           <p className="text-xs text-[var(--landing-text-muted)] uppercase tracking-wide mb-1">
-            {plan.key === 'FREE' ? 'Basic' : plan.name}
+            {plan.key === 'FREE' ? 'Trial' : plan.name}
           </p>
           <h3
             className="text-2xl font-bold"
@@ -105,7 +105,7 @@ export function PricingCard({
               Free
             </span>
             <span className="text-[var(--landing-text-muted)]">
-              forever
+              for 7 days
             </span>
           </div>
         ) : (
@@ -212,7 +212,7 @@ export function PricingCard({
           <div className="flex items-center gap-2 text-sm text-[var(--landing-text-muted)]">
             <span className="text-[var(--landing-primary)]">+</span>
             <span>
-              Everything in {plan.key === 'PRO' ? 'Free' : 'Pro'}
+              Everything in {plan.key === 'PRO' ? 'Trial' : 'Pro'}
             </span>
           </div>
         </div>

--- a/components/landing/pricing-section-3-tier.tsx
+++ b/components/landing/pricing-section-3-tier.tsx
@@ -53,15 +53,15 @@ export function PricingSection3Tier() {
     {
       name: 'FREE',
       price: '$0',
-      period: 'forever',
-      description: 'Perfect for trying out tldrsec.ai',
+      period: 'for 7 days',
+      description: 'Full access trial',
       features: [
-        '3 companies to track',
-        'Weekly digest emails',
-        '10-K and 10-Q summaries only',
-        'Basic filing alerts',
+        'Unlimited companies to track',
+        'Real-time email alerts',
+        'All SEC filing types',
+        'First priority processing queue',
       ],
-      buttonText: 'Start FREE Trial',
+      buttonText: 'Start Trial',
       popular: false,
     },
     {

--- a/components/landing/sections-v2/cta-section-v2.tsx
+++ b/components/landing/sections-v2/cta-section-v2.tsx
@@ -13,7 +13,7 @@ import { viewportOnce } from '@/lib/animations/landing-animations';
  */
 const trustPoints = [
   'No credit card required',
-  'Start with 3 free tickers',
+  'Start with unlimited tickers',
   'Cancel anytime',
 ];
 

--- a/components/landing/sections-v2/pricing-section-v2.tsx
+++ b/components/landing/sections-v2/pricing-section-v2.tsx
@@ -29,9 +29,9 @@ const plans = [
     icon: Zap,
     monthlyPrice: SUBSCRIPTION_PLANS.FREE.monthlyPrice,
     annualPrice: SUBSCRIPTION_PLANS.FREE.annualPrice,
-    description: 'Get started with SEC filings',
+    description: 'Full access for 7 days',
     features: SUBSCRIPTION_PLANS.FREE.features,
-    cta: 'Get Started',
+    cta: 'Start Free Trial',
     href: '/onboarding',
     popular: false,
     disabled: false,
@@ -207,7 +207,7 @@ export function PricingSectionV2() {
             Simple, Transparent Pricing
           </h2>
           <p className="landing-body max-w-2xl mx-auto mb-8">
-            Start free, upgrade when you&apos;re ready. No hidden fees.
+            Start with a free trial, upgrade when you&apos;re ready. No hidden fees.
           </p>
         </motion.div>
 

--- a/components/landing/sections/cta-section.tsx
+++ b/components/landing/sections/cta-section.tsx
@@ -24,7 +24,7 @@ export function NewCTASection() {
           </h2>
           <p className="text-lg text-blue-100 mb-8">
             Join thousands of investors who use tldrsec.app to stay informed
-            without the time commitment. Start your free trial today.
+            without the time commitment. Start your trial today.
           </p>
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
             <Link href="/sign-up">
@@ -32,7 +32,7 @@ export function NewCTASection() {
                 size="lg"
                 className="h-14 px-8 text-base font-semibold bg-white text-blue-600 hover:bg-blue-50 shadow-xl"
               >
-                Start Free Trial
+                Start Trial
                 <ArrowRight className="w-5 h-5 ml-2" />
               </Button>
             </Link>
@@ -47,7 +47,7 @@ export function NewCTASection() {
             </Link>
           </div>
           <p className="mt-6 text-sm text-blue-200">
-            No credit card required. Free plan available.
+            No credit card required.
           </p>
         </motion.div>
       </div>

--- a/components/landing/sections/filing-preview-card.tsx
+++ b/components/landing/sections/filing-preview-card.tsx
@@ -161,7 +161,7 @@ export function FilingPreviewCard({ filing, index }: FilingPreviewCardProps) {
               Want summaries like this for your portfolio?
             </p>
             <Button asChild>
-              <Link href="/sign-up">Start Free Trial</Link>
+              <Link href="/sign-up">Start Trial</Link>
             </Button>
           </div>
         </DialogContent>

--- a/components/landing/sections/hero-section.tsx
+++ b/components/landing/sections/hero-section.tsx
@@ -92,7 +92,7 @@ export function NewHeroSection() {
                 size="lg"
                 className="h-14 px-8 text-base font-semibold bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 shadow-lg shadow-blue-500/25"
               >
-                Start Free Trial
+                Start Trial
                 <ArrowRight className="w-5 h-5 ml-2" />
               </Button>
             </Link>

--- a/components/landing/sections/pricing-section.tsx
+++ b/components/landing/sections/pricing-section.tsx
@@ -51,7 +51,7 @@ function PricingCard({
 
   const ctaText =
     planKey === 'FREE'
-      ? 'Start Free Trial'
+      ? 'Start Trial'
       : planKey === 'PRO'
         ? 'Start Pro Trial'
         : 'Start Max';
@@ -179,7 +179,7 @@ export function NewPricingSection() {
             Simple, Transparent Pricing
           </h2>
           <p className="text-lg text-slate-600 max-w-2xl mx-auto">
-            Start free and upgrade when you need more. No hidden fees, cancel
+            Start with a trial, upgrade when you need more. No hidden fees, cancel
             anytime.
           </p>
         </motion.div>
@@ -248,8 +248,7 @@ export function NewPricingSection() {
           className="mt-16 text-center"
         >
           <p className="text-sm text-slate-500">
-            All plans include 14-day free trial. No credit card required for
-            Free plan.
+            All plans include 7-day trial. No credit card required.
           </p>
         </motion.div>
       </div>

--- a/components/settings/UserProfileSection.tsx
+++ b/components/settings/UserProfileSection.tsx
@@ -165,7 +165,7 @@ export default function UserProfileSection({ user }: UserProfileSectionProps) {
           <div className="rounded-lg border border-blue-100 bg-blue-50 p-4">
             <div className="flex justify-between">
               <div>
-                <h3 className="font-semibold">Free Plan</h3>
+                <h3 className="font-semibold">Trial</h3>
                 <p className="text-sm">$0/month</p>
               </div>
               <span className="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold bg-blue-100 text-blue-800 border-blue-200">

--- a/docs/plans/2026-03-13-rename-free-to-trial-ui.md
+++ b/docs/plans/2026-03-13-rename-free-to-trial-ui.md
@@ -1,0 +1,272 @@
+# Rename "Free" to "Trial" with Max-Level Features (UI-Only)
+
+**Date**: 2026-03-13
+**Branch**: worktree-trial-tier
+**Status**: Reviewed — Ready for Implementation
+**Reviewed**: 2026-03-13 (16 issues resolved)
+
+## Overview
+
+Rename all user-facing "Free" text to "Trial" and unlock max-level features (unlimited tickers) for trial users. This is a **UI-only rename** — no database migration, no Prisma enum changes. The DB value `FREE` stays as-is.
+
+## Design Decision: UI-Only Rename (No DB Migration)
+
+Keep `FREE` in Prisma enums and database. Display "Trial" in all user-facing surfaces. This avoids a risky PostgreSQL enum migration and keeps backward compatibility with Stripe webhooks, Clerk, and pipeline processing.
+
+---
+
+## Phase 1: Plan Configuration (Central Source of Truth)
+
+### Task 1.1: `lib/stripe/plans.ts`
+- [x] Change `FREE.name` from `'Free'` to `'Trial'`
+- [x] Change `FREE.tickerLimit` from `3` to `-1` (unlimited, same as MAX)
+- [x] Update features array:
+  - `'3 companies to track'` → `'**Unlimited** companies'`
+  - `'7-day free trial'` → `'7-day trial period'`
+  - Add `'**First** priority processing queue'` and `'Dedicated support'` to match MAX
+
+### Task 1.2: `lib/subscription/three-tier-limits.ts`
+- [x] Change `FREE: 3` to `FREE: -1` (unlimited)
+
+### Task 1.3: Create shared `UserSubscription` type — `lib/types/subscription.ts`
+- [x] Create `lib/types/subscription.ts` with a single `UserSubscription` interface containing all fields:
+  - `planType`, `isActive`, `currentPeriodEnd`, `cancelAtPeriodEnd`, `stripeCustomerId?`, `stripeSubscriptionId?`
+  - `isTrialing`, `daysRemaining`, `trialEndsAt`, `isGrandfathered` (already returned by `/api/user/subscription` GET)
+- [x] Import this type in both `app/subscribe/page.tsx` and `app/dashboard/billing/page.tsx` (replacing local interfaces)
+
+> **Review Note**: The subscription API already returns `isTrialing`, `daysRemaining`, `trialEndsAt`, `isGrandfathered` in all response paths (route.ts lines 66-69, 92-95, 126-129). No API changes needed — just update TypeScript interfaces to consume existing data.
+
+---
+
+## Phase 2: Subscribe Page (`app/subscribe/page.tsx`)
+
+### Task 2.1: Remove FREE card, show only PRO and MAX
+- [x] Change `PLAN_ORDER` from `['FREE', 'PRO', 'MAX']` to `['PRO', 'MAX']`
+- [x] Change grid from `md:grid-cols-3` to `md:grid-cols-2`
+- [x] Update skeleton loading to show 2 cards instead of 3
+
+### Task 2.2: Add trial info banner above grid
+- [x] Import shared `UserSubscription` type from `lib/types/subscription.ts`
+- [x] Add banner above grid: "You're on a Trial (X days remaining)" for FREE users
+- [x] For expired trial users: "Trial Expired — Upgrade to continue"
+
+### Task 2.3: Clean up button types and footers
+- [x] Remove `case 'free':` button type (no longer shown)
+- [x] Remove "Everything in Free" footer from PRO card
+- [x] Keep "Everything in Pro" on MAX card
+- [x] Remove downgrade-to-FREE option (paid users cancel from billing page)
+
+---
+
+## Phase 3: Landing Page Pricing
+
+### Task 3.1: `components/landing/sections-v2/pricing-section-v2.tsx`
+- [x] Update FREE plan entry: `description` → `'Full access for 7 days'`, `cta` → `'Start Free Trial'`
+- [x] Update subheader: `"Start free, upgrade when you're ready"` → `"Start with a free trial, upgrade when you're ready"`
+
+### Task 3.2: `components/landing/pricing-card.tsx`
+- [x] Change price display from `"Free" + "forever"` to `"Free"` + `"for 7 days"`
+- [x] Change sub-header from `'Basic'` to `'Trial'` for FREE key
+- [x] Remove "Everything in Free" footer for PRO card → change to "Everything in Trial"
+- [x] Keep "Everything in Pro" on MAX card
+
+### Task 3.3: `components/landing/sections-v2/cta-section-v2.tsx` (NEW)
+- [x] Update `'Start with 3 free tickers'` → `'Start with unlimited tickers'` (reflects new unlimited limit)
+
+### Task 3.4: V1 Landing Sections (still active when V2 flag is off)
+- [x] `components/landing/sections/cta-section.tsx`:
+  - `"Start your free trial today."` → `"Start your trial today."`
+  - `"Start Free Trial"` → `"Start Trial"`
+  - `"No credit card required. Free plan available."` → `"No credit card required."`
+- [x] `components/landing/sections/hero-section.tsx`:
+  - `"Start Free Trial"` → `"Start Trial"`
+- [x] `components/landing/sections/pricing-section.tsx`:
+  - `'Start Free Trial'` → `'Start Trial'`
+  - `"Start free and upgrade when you need more."` → `"Start with a trial, upgrade when you need more."`
+  - `"14-day free trial"` → `"7-day trial"` (FIX: was incorrect — actual trial is 7 days)
+  - `"No credit card required for Free plan."` → `"No credit card required."`
+- [x] `components/landing/sections/filing-preview-card.tsx`:
+  - `"Start Free Trial"` → `"Start Trial"`
+
+---
+
+## Phase 4: Dashboard Billing Page (`app/dashboard/billing/page.tsx`)
+
+### Task 4.1: Update subscription display
+- [x] Import shared `UserSubscription` type from `lib/types/subscription.ts`
+- [x] For trial users: show "Trial — X days remaining" instead of "$0/month"
+- [x] For grandfathered users: show "Trial" (same display as regular trial users)
+- [x] For expired trial users: show "Trial Expired — Upgrade to continue receiving summaries"
+- [x] Keep "Upgrade Plan" button for all FREE-tier users
+
+---
+
+## Phase 5: Plan Status Banner (`components/dashboard/plan-status-banner.tsx`)
+
+### Task 5.1: Update banner text
+- [x] Change `"free trial"` to `"trial"` in banner text
+
+---
+
+## Phase 6: Additional User-Facing Surfaces (NEW)
+
+### Task 6.1: Settings page — `components/settings/UserProfileSection.tsx`
+- [x] Change `<h3>Free Plan</h3>` → `<h3>Trial</h3>` (line 168)
+
+### Task 6.2: Subscription API toast message — `app/api/user/subscription/route.ts`
+- [x] Change `'Subscription will be downgraded to Free at the end of the billing period'` → `'Subscription will be downgraded to Trial at the end of the billing period'` (line 525)
+- [x] Change `'Free tier does not require checkout'` → `'Trial tier does not require checkout'` (line 194)
+
+### Task 6.3: Email templates — `lib/email/trial-emails.ts`
+- [x] `"Your 7-day free trial has started."` → `"Your 7-day trial has started."` (lines 43, 63)
+- [x] `"Your free trial ends on..."` → `"Your trial ends on..."` (line 96)
+- [x] `"Your 7-day free trial ended on..."` → `"Your 7-day trial ended on..."` (line 141)
+
+---
+
+## Phase 7: Onboarding Fix (CRITICAL — NEW)
+
+### Task 7.1: Fix `app/(auth)/onboarding/onboarding-client.tsx`
+- [x] `MAX_TICKERS = THREE_TIER_LIMITS.FREE` (line 26) — when this becomes `-1`, the guard `prev.length < MAX_TICKERS` is always `false`, preventing ANY ticker adds
+- [x] Add `isUnlimited` guard (same pattern as `dashboard-client.tsx:358-359`)
+- [x] Fix counter text: `"X of ${MAX_TICKERS} tickers selected"` → show `"X tickers selected"` when unlimited
+- [x] Add soft cap of ~10-15 tickers in onboarding picker UI only (not server-enforced) to mitigate pipeline cost risk from trial users adding excessive tickers
+- [x] Update equity button disable logic (line 559) to respect unlimited
+
+> **Review Note**: Without this fix, no new user can add tickers during onboarding — product-breaking bug.
+
+---
+
+## Phase 8: Processing Queue (No Changes Needed)
+
+- `tier-eligibility.ts`: FREE→HOBBY mapping stays (trial users get lower processing priority than paid)
+- `async-filing-queue.ts`: Priority values stay as-is
+- Email ordering remains: Max/Pro first (PRO tier), then Trial (HOBBY tier)
+- Pipeline cost mitigated by: 7-day trial expiry, 120-min HOBBY frequency, shared summary deduplication, soft onboarding cap
+
+---
+
+## Phase 9: Test Updates
+
+### Task 9.1: Update existing test assertions
+
+| Test File | Changes Needed |
+|---|---|
+| `__tests__/config/stripe-pricing.test.ts` | `tickerLimit: 3` → `-1`; FIX stale: `filingTypes: ['10-K','10-Q']` → `['ALL']`; FIX stale: `emailFrequency: 'weekly'` → `'realtime'` |
+| `__tests__/components/landing/pricing-card.test.tsx` | Update fixture `name: 'Free'` → `'Trial'`; `features: '3 companies to track'` → unlimited; `'Everything in Free'` → `'Everything in Trial'` |
+| `__tests__/components/landing/pricing-section-v2.test.tsx` | `toContain('Free')` → `'Trial'`; `getByText('Free')` → price display; `3 companies` → unlimited |
+| `__tests__/api/three-tier-limits.test.ts` | **Rewrite** FREE tests: assert unlimited behavior (`limitReached: false` for any count, `unlimited: true`) |
+| `__tests__/app/subscribe/page.test.tsx` | **Rewrite** for 2-card + banner layout: remove Free heading assertions, add trial banner assertions, update card count |
+| `__tests__/app/dashboard/billing/page.test.tsx` | Update `'3 companies'` → unlimited display; update plan name assertions |
+| `__tests__/components/landing/hero-section-v2.test.tsx` | Update `'Start Free Trial'` CTA if changed |
+| `__tests__/components/pricing-section-3-tier.test.tsx` | Update `'FREE'` text, `'3 companies'`, `'Start FREE Trial'` |
+| `__tests__/integration/direct-checkout-flow.test.ts` | Update mock `tickerLimit: 3` → `-1` |
+| `__tests__/e2e/pricing-max-tier.test.ts` | Update `text=Free` locator |
+
+### Task 9.2: Create new test files
+- [x] `__tests__/components/dashboard/plan-status-banner.test.tsx` — test banner renders with trial/expired/grandfathered states (9 tests)
+- [x] `__tests__/components/settings/user-profile-section.test.tsx` — test "Trial" display in settings (3 tests)
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `lib/stripe/plans.ts` | Rename FREE, unlock features |
+| `lib/subscription/three-tier-limits.ts` | FREE limit → -1 |
+| `lib/types/subscription.ts` | **NEW** — shared UserSubscription type |
+| `app/subscribe/page.tsx` | Remove FREE card, 2-col grid, trial banner, use shared type |
+| `components/landing/sections-v2/pricing-section-v2.tsx` | Update FREE plan display |
+| `components/landing/pricing-card.tsx` | "Trial" display, "Everything in Trial" |
+| `components/landing/sections-v2/cta-section-v2.tsx` | **NEW** — "unlimited tickers" |
+| `components/landing/sections/cta-section.tsx` | **NEW** — V1 "trial" text |
+| `components/landing/sections/hero-section.tsx` | **NEW** — V1 "trial" CTA |
+| `components/landing/sections/pricing-section.tsx` | **NEW** — V1 "trial" + fix 14→7 day |
+| `components/landing/sections/filing-preview-card.tsx` | **NEW** — V1 "trial" CTA |
+| `app/dashboard/billing/page.tsx` | Show trial days remaining, use shared type |
+| `components/dashboard/plan-status-banner.tsx` | "trial" text |
+| `components/settings/UserProfileSection.tsx` | **NEW** — "Trial" heading |
+| `app/api/user/subscription/route.ts` | **NEW** — toast message text |
+| `lib/email/trial-emails.ts` | **NEW** — "trial" in email templates |
+| `app/(auth)/onboarding/onboarding-client.tsx` | **CRITICAL NEW** — fix unlimited ticker handling + soft cap |
+| Test files (10 existing + 2 new) | Update assertions, rewrite FREE tests |
+
+## What We Do NOT Change
+
+- Prisma schema enums (FREE/PRO/MAX stay)
+- Database data (no migration)
+- Stripe webhook handlers
+- Clerk webhook (still creates users as FREE)
+- Trial service logic
+- Processing queue ordering
+- Validation schemas (FREE stays valid in Zod)
+- Subscription API response shape (already returns trial fields)
+
+## Verification
+
+1. `npm run lint` — no errors
+2. `npm run test` — all unit tests pass (including rewritten tests)
+3. Visual check: landing page shows "Trial" card with "Start Free Trial" CTA
+4. Visual check: subscribe page shows only PRO and MAX with trial banner
+5. Visual check: billing page shows "Trial — X days remaining" for trial users
+6. Visual check: settings page shows "Trial" not "Free Plan"
+7. Visual check: onboarding allows adding tickers (soft capped at ~10-15)
+8. Verify trial users can track unlimited companies (tickerLimit = -1)
+9. Verify onboarding counter shows "X tickers selected" (no "-1")
+
+## Resolved Decisions
+
+1. **Landing page layout**: Keep 3 cards (Trial + Pro + Max) so visitors see the trial option prominently.
+2. **Grandfathered users**: Show as "Trial" (same as regular trial users).
+3. **Expired trial**: Show "Trial Expired — Upgrade to continue receiving summaries".
+
+## Review Notes
+
+Reviewed 2026-03-13. 16 issues identified and resolved:
+
+- **Issues 1, 7, 8**: Added 9 missed files (V1 sections, V2 CTA, settings, API route, email templates) to plan scope
+- **Issue 2**: Extract shared `UserSubscription` type to `lib/types/subscription.ts` (DRY)
+- **Issues 3, 5**: Subscription API already returns trial fields — no API changes needed, just interface updates
+- **Issue 4, 11**: Fix 2 pre-existing stale assertions in `stripe-pricing.test.ts` (`filingTypes`, `emailFrequency`)
+- **Issue 6**: Fix V1 pricing "14-day" → "7-day" (factual error)
+- **Issues 9, 10, 12**: Add 2 new test files (banner, settings); rewrite subscribe tests for 2-card layout; rewrite three-tier-limits tests for unlimited
+- **Issues 13, 15**: CRITICAL — fix onboarding `MAX_TICKERS = -1` breaking bug (no tickers can be added)
+- **Issue 14**: Add soft cap (~10-15) in onboarding picker to mitigate pipeline cost from unlimited trial tickers
+
+---
+
+## Implementation Log
+
+### Phase 1 — Complete
+- `lib/stripe/plans.ts`: Changed FREE.name to 'Trial', tickerLimit to -1, updated features array with unlimited + priority + support
+- `lib/subscription/three-tier-limits.ts`: Changed FREE limit from 3 to -1
+- `lib/types/subscription.ts`: Created shared UserSubscription interface with all fields including trial state
+
+### Phase 2 — Complete
+- `app/subscribe/page.tsx`: Removed FREE from PLAN_ORDER (now PRO/MAX only), 2-col grid, trial banner for FREE users, removed 'free' button type case, MAX-only "Everything in Pro" footer, imported shared UserSubscription type
+
+### Phase 3 — Complete
+- `pricing-section-v2.tsx`: Updated FREE plan description/cta, subheader text
+- `pricing-card.tsx`: "Free" → "for 7 days", "Basic" → "Trial", "Everything in Free" → "Everything in Trial"
+- `cta-section-v2.tsx`: "3 free tickers" → "unlimited tickers"
+- V1 sections: cta-section (trial text, no "Free plan available"), hero-section (Start Trial), pricing-section (Start Trial, 7-day trial, no credit card), filing-preview-card (Start Trial)
+
+### Phase 4 — Complete
+- `app/dashboard/billing/page.tsx`: Shared UserSubscription type, trial status text ("Trial — X days remaining" or "Trial Expired"), plan name "Trial" for FREE users
+
+### Phase 5 — Complete
+- `plan-status-banner.tsx`: "free trial" → "trial"
+
+### Phase 6 — Complete
+- `UserProfileSection.tsx`: "Free Plan" → "Trial"
+- `subscription/route.ts`: "Free tier" → "Trial tier", "downgraded to Free" → "downgraded to Trial"
+- `trial-emails.ts`: "free trial" → "trial" in welcome, reminder, expiration emails
+
+### Phase 7 — Complete (CRITICAL)
+- `onboarding-client.tsx`: Added isUnlimited guard, soft cap of 15 tickers for onboarding, dynamic counter text ("X tickers selected" when unlimited), dynamic description text
+
+### Phase 9 — Complete (Tests)
+- Updated 8 existing test files: stripe-pricing, pricing-card, pricing-section-v2, three-tier-limits, subscribe/page, billing/page, pricing-section-3-tier, direct-checkout-flow
+- Also updated pricing-max-tier e2e test (Free → Trial locator)
+- Also updated pricing-section-3-tier component source (was hardcoded, not using SUBSCRIPTION_PLANS)

--- a/lib/email/trial-emails.ts
+++ b/lib/email/trial-emails.ts
@@ -40,7 +40,7 @@ export async function sendTrialWelcomeEmail(
       <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
         <h1 style="color: #1a1a2e; font-size: 24px;">Welcome to tldrSEC${name ? `, ${name}` : ''}!</h1>
         <p style="color: #4a4a5a; font-size: 16px; line-height: 1.6;">
-          Your 7-day free trial has started. Here's what you get:
+          Your 7-day trial has started. Here's what you get:
         </p>
         <ul style="color: #4a4a5a; font-size: 16px; line-height: 1.8;">
           <li>Track up to 3 companies</li>
@@ -60,7 +60,7 @@ export async function sendTrialWelcomeEmail(
         </p>
       </div>
     `,
-    text: `Welcome to tldrSEC${name ? `, ${name}` : ''}! Your 7-day free trial has started. Track up to 3 companies with all SEC filing types. Your trial ends on ${trialEndsAt.toLocaleDateString()}. Visit ${APP_URL}/dashboard to get started.`,
+    text: `Welcome to tldrSEC${name ? `, ${name}` : ''}! Your 7-day trial has started. Track up to 3 companies with all SEC filing types. Your trial ends on ${trialEndsAt.toLocaleDateString()}. Visit ${APP_URL}/dashboard to get started.`,
     tags: ['type:trial-welcome'],
   };
 
@@ -93,7 +93,7 @@ export async function sendTrialReminderEmail(
       <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
         <h1 style="color: #1a1a2e; font-size: 24px;">Your trial ${urgency}</h1>
         <p style="color: #4a4a5a; font-size: 16px; line-height: 1.6;">
-          Your free trial ends on <strong>${trialEndsAt.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })}</strong>.
+          Your trial ends on <strong>${trialEndsAt.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })}</strong>.
           Upgrade now to keep receiving AI-powered SEC filing summaries.
         </p>
         <div style="text-align: center; margin: 30px 0;">
@@ -138,7 +138,7 @@ export async function sendTrialExpirationEmail(
       <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
         <h1 style="color: #1a1a2e; font-size: 24px;">Your trial has ended</h1>
         <p style="color: #4a4a5a; font-size: 16px; line-height: 1.6;">
-          Your 7-day free trial ended on ${trialExpiredAt.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })}.
+          Your 7-day trial ended on ${trialExpiredAt.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })}.
         </p>
         <p style="color: #4a4a5a; font-size: 16px; line-height: 1.6;">
           You can still access the dashboard and view your existing summaries, but you won't receive new filing notifications until you upgrade.

--- a/lib/stripe/plans.ts
+++ b/lib/stripe/plans.ts
@@ -10,19 +10,21 @@
 // =============================================================================
 export const SUBSCRIPTION_PLANS = {
   FREE: {
-    name: 'Free',
+    name: 'Trial',
     monthlyPriceId: null,
     annualPriceId: null,
     monthlyPrice: 0,
     annualPrice: 0,
-    tickerLimit: 3,
+    tickerLimit: -1, // unlimited (same as MAX)
     filingTypes: ['ALL'] as const, // Trial users get all filing types to showcase full product
     emailFrequency: 'realtime' as const,
     features: [
-      '3 companies to track',
+      '**Unlimited** companies',
       'Real-time email alerts',
       'All SEC filing types',
-      '7-day free trial',
+      '7-day trial period',
+      '**First** priority processing queue',
+      'Dedicated support',
     ],
   },
   PRO: {

--- a/lib/subscription/three-tier-limits.ts
+++ b/lib/subscription/three-tier-limits.ts
@@ -1,6 +1,6 @@
 // Simplified 3-tier system with MAX unlimited
 export const THREE_TIER_LIMITS = {
-  FREE: 3,
+  FREE: -1, // unlimited (same as MAX)
   PRO: 25,
   MAX: -1  // -1 = unlimited (no validation needed)
 } as const;

--- a/lib/types/subscription.ts
+++ b/lib/types/subscription.ts
@@ -1,0 +1,18 @@
+import type { PlanType } from '@/lib/stripe/plans';
+
+/**
+ * Shared UserSubscription type used across subscribe page, billing page,
+ * and other components that consume the /api/user/subscription endpoint.
+ */
+export interface UserSubscription {
+  planType: PlanType;
+  isActive: boolean;
+  currentPeriodEnd: string;
+  cancelAtPeriodEnd: boolean;
+  stripeCustomerId?: string;
+  stripeSubscriptionId?: string;
+  isTrialing: boolean;
+  daysRemaining: number;
+  trialEndsAt: string | null;
+  isGrandfathered: boolean;
+}


### PR DESCRIPTION
## Summary
- Rename "Free" tier to "Trial" across all user-facing surfaces (pricing pages, dashboard, billing, onboarding, emails, settings)
- Add expired trial banner on dashboard prompting upgrade when trial period ends
- Fix Stripe subscription not syncing for re-onboarded users (handles existing subscriptions during re-onboarding)
- Add unlimited ticker tracking for Trial tier users

## Changes
- **UI Rename (35 files)**: Updated all references from "Free" to "Trial" in pricing cards, CTA sections, hero section, billing page, subscribe page, onboarding flow, email templates, and user profile settings
- **Expired Trial Banner**: New `PlanStatusBanner` component shows contextual banners for expired trials vs active subscriptions, integrated into dashboard page
- **Subscription Sync Fix**: `app/api/user/subscription/route.ts` and `app/(auth)/onboarding/actions.ts` now check for existing Stripe subscriptions during re-onboarding and sync them properly
- **Type System**: Added `SubscriptionDisplayInfo` type and `getSubscriptionDisplayInfo()` helper for consistent tier display logic
- **Tests**: New tests for `PlanStatusBanner` and `UserProfileSection`, updated existing tests for Free→Trial rename

## Test Plan
- [ ] Unit tests pass (`npm run test`)
- [ ] Pricing card tests updated for Trial naming
- [ ] PlanStatusBanner component tests (104 lines of new tests)
- [ ] UserProfileSection tests verify Trial display
- [ ] Subscription sync handles re-onboarding edge case
- [ ] Expired trial banner renders correctly on dashboard

## Related Issues
Closes the Free→Trial tier rename initiative

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>