### PR TITLE
docs: add gstack browser & workflow skills to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -797,3 +797,39 @@ See `docs/architecture/job-retry-patterns.md` for:
 - **Cloudflare Worker Updates**: Worker deployment should be coordinated with Vercel deployments
 - **Database Migrations**: New alert and security audit tables require migration
 - **Environment Variables**: Additional monitoring configuration variables required for full functionality
+
+## gstack (Browser & Workflow Skills)
+
+Use the `/browse` skill from gstack for all web browsing. Never use `mcp__claude-in-chrome__*` tools.
+
+### Available Skills
+
+| Skill | Purpose |
+|-------|---------|
+| `/office-hours` | YC-style brainstorming and idea validation |
+| `/plan-ceo-review` | CEO/founder-mode plan review |
+| `/plan-eng-review` | Engineering manager plan review |
+| `/plan-design-review` | Designer's eye plan review |
+| `/design-consultation` | Design system creation (DESIGN.md) |
+| `/review` | Pre-landing PR code review |
+| `/ship` | Ship workflow (test, review, PR) |
+| `/land-and-deploy` | Merge PR, deploy, verify production |
+| `/canary` | Post-deploy canary monitoring |
+| `/benchmark` | Performance regression detection |
+| `/browse` | Headless browser for testing and dogfooding |
+| `/qa` | QA test and fix bugs |
+| `/qa-only` | QA report only (no fixes) |
+| `/design-review` | Visual QA and design polish |
+| `/setup-browser-cookies` | Import browser cookies for authenticated testing |
+| `/setup-deploy` | Configure deployment settings |
+| `/retro` | Weekly engineering retrospective |
+| `/investigate` | Systematic root cause debugging |
+| `/document-release` | Post-ship documentation update |
+| `/codex` | OpenAI Codex second opinion |
+| `/cso` | Security audit (OWASP, STRIDE, supply chain) |
+| `/autoplan` | Auto-review pipeline (CEO + design + eng) |
+| `/careful` | Safety guardrails for destructive commands |
+| `/freeze` | Restrict edits to a specific directory |
+| `/guard` | Full safety mode (careful + freeze) |
+| `/unfreeze` | Remove directory edit restrictions |
+| `/gstack-upgrade` | Upgrade gstack to latest version |


### PR DESCRIPTION
## Summary
- Add gstack skills documentation section to CLAUDE.md
- Document 27 available skills with descriptions (browse, ship, qa, review, etc.)
- Establish `/browse` as the standard for web browsing instead of `mcp__claude-in-chrome__*` tools

## Test Coverage
No application code changed — docs-only PR.

## Pre-Landing Review
No issues found.

## Test plan
- [x] CLAUDE.md renders correctly with new section
- [x] No application code changes — no functional risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)