### PR TITLE
fix: pipeline stall from missing DB columns and executionContext crash

### DIFF
--- a/lib/cron/handlers/summarize-cached-handler.ts
+++ b/lib/cron/handlers/summarize-cached-handler.ts
@@ -65,7 +65,7 @@ export async function handleSummarizeCached(
 ): Promise<SummarizeResult> {
   const startTime = Date.now();
   const { userId, userEmail, userTier: _userTier, ticker, filing, cacheId, executionContext } = payload;
-  const { executionId } = executionContext;
+  const executionId = executionContext?.executionId ?? `legacy-${Date.now()}`;
 
   summarizeLogger.info(`[${executionId}] Starting summarize phase`, {
     userId,
@@ -73,7 +73,7 @@ export async function handleSummarizeCached(
     formType: filing.formType,
     accessionNumber: filing.accessionNumber,
     cacheId,
-    cacheHit: executionContext.cacheHit
+    cacheHit: executionContext?.cacheHit
   });
 
   try {
@@ -427,10 +427,10 @@ export async function handleSummarizeCached(
               cacheId,
               cacheHit: true,
               summarizeDuration: 0,
-              cronTriggerTime: executionContext.cronTriggerTime,
-              sourceContext: executionContext.sourceContext,
-              discoveryPhaseCompletedAt: executionContext.discoveryPhaseCompletedAt,
-              fetchPhaseCompletedAt: executionContext.fetchPhaseCompletedAt,
+              cronTriggerTime: executionContext?.cronTriggerTime,
+              sourceContext: executionContext?.sourceContext,
+              discoveryPhaseCompletedAt: executionContext?.discoveryPhaseCompletedAt,
+              fetchPhaseCompletedAt: executionContext?.fetchPhaseCompletedAt,
               summarizePhaseCompletedAt: new Date().toISOString(),
               ticker: ticker.symbol,
               companyName: ticker.companyName,
@@ -654,18 +654,18 @@ export async function handleSummarizeCached(
         totalCost: summaryResult.cost || 0,
         inputTokens: summaryResult.inputTokens || 0,
         outputTokens: summaryResult.outputTokens || 0,
-        isCacheHit: executionContext.cacheHit || false,
+        isCacheHit: executionContext?.cacheHit || false,
         processingCompletedAt: new Date(), // Fix: Add missing completion timestamp
         processingTimeMs: summarizeDuration,  // AI processing duration in ms
         metadata: {
           executionId,
           cacheId,
-          cacheHit: executionContext.cacheHit,
+          cacheHit: executionContext?.cacheHit,
           summarizeDuration,
-          cronTriggerTime: executionContext.cronTriggerTime,
-          sourceContext: executionContext.sourceContext,
-          discoveryPhaseCompletedAt: executionContext.discoveryPhaseCompletedAt,
-          fetchPhaseCompletedAt: executionContext.fetchPhaseCompletedAt,
+          cronTriggerTime: executionContext?.cronTriggerTime,
+          sourceContext: executionContext?.sourceContext,
+          discoveryPhaseCompletedAt: executionContext?.discoveryPhaseCompletedAt,
+          fetchPhaseCompletedAt: executionContext?.fetchPhaseCompletedAt,
           summarizePhaseCompletedAt: new Date().toISOString(),
           ticker: ticker.symbol,
           companyName: ticker.companyName,
@@ -795,8 +795,8 @@ export async function handleSummarizeCached(
       emailSent,
       totalDuration,
       phases: {
-        discovery: executionContext.discoveryPhaseCompletedAt,
-        fetch: executionContext.fetchPhaseCompletedAt,
+        discovery: executionContext?.discoveryPhaseCompletedAt,
+        fetch: executionContext?.fetchPhaseCompletedAt,
         summarize: new Date().toISOString()
       }
     });

--- a/prisma/migrations/20260328_add_missing_columns/migration.sql
+++ b/prisma/migrations/20260328_add_missing_columns/migration.sql
@@ -1,0 +1,32 @@
+-- Migration: Add missing columns from PRs #372 and #374
+-- These columns were added to schema.prisma but never migrated to the database,
+-- causing pipeline failures from 2026-03-26 onward.
+
+-- TickerMonitoring: SEC Submissions API fast-poll watermarks (PR #374)
+ALTER TABLE "app"."TickerMonitoring"
+  ADD COLUMN IF NOT EXISTS "lastSeenAcceptanceDateTime" TEXT,
+  ADD COLUMN IF NOT EXISTS "lastEtag" TEXT,
+  ADD COLUMN IF NOT EXISTS "lastPollTime" TIMESTAMPTZ;
+
+-- Summary: delivery latency tracking (PR #374)
+ALTER TABLE "app"."Summary"
+  ADD COLUMN IF NOT EXISTS "edgarAcceptedAt" TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS "deliveryLatencyMs" INTEGER;
+
+-- Summary: importance scoring and smart subjects (PR #372)
+ALTER TABLE "app"."Summary"
+  ADD COLUMN IF NOT EXISTS "importance" TEXT,
+  ADD COLUMN IF NOT EXISTS "smartSubject" TEXT;
+
+-- User: soft delete support (PR #372)
+ALTER TABLE "app"."User"
+  ADD COLUMN IF NOT EXISTS "deletedAt" TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS "deleteScheduledFor" TIMESTAMPTZ;
+
+-- User: hours saved tracking (PR #372)
+ALTER TABLE "app"."User"
+  ADD COLUMN IF NOT EXISTS "hoursSavedThisMonth" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS "hoursSavedTotal" INTEGER NOT NULL DEFAULT 0;
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS "User_deletedAt_idx" ON "app"."User" ("deletedAt");


### PR DESCRIPTION
## Summary

Fixes a 2-day pipeline outage (March 26-28, 2026). No email summaries were sent since Thursday morning.

**Root cause:** PRs #372 and #374 added 11 columns to `schema.prisma` without creating database migrations. When deployed:
- The `fast-poll` endpoint (SEC Submissions API) hit `TickerMonitoring.lastPollTime does not exist`, returning 500 on every call
- The summarize handler crashed on `Cannot destructure property 'executionId' of 'executionContext' as it is undefined` for all pre-existing jobs
- Auto-recovery looped 981 times doing nothing useful

**Production remediation already applied:**
- 11 missing columns added to prod DB via direct SQL
- Recovery state reset (consecutiveCleanups: 981 → 0)
- 23,416 failed jobs cleaned from queue

**This PR adds:**
- Optional chaining for `executionContext` in `summarize-cached-handler.ts` (7 locations)
- Migration SQL file documenting the columns added to prod

## Test Coverage

No new code paths. All changes are `executionContext.X` → `executionContext?.X` null safety guards. 25 pre-existing test failures in `summarize-cached-handler` tests (identical count with and without this change, from PR #374 not updating test payloads).

## Pre-Landing Review

No issues found. Pure defensive null guards.

## Test plan
- [x] Lint passes (0 warnings, 0 errors)
- [x] Pre-existing test failures verified unchanged (25 fail before and after)
- [x] Production fast-poll endpoint returns 200 (was 500)
- [x] Production process-queue processes jobs successfully
- [x] HMAC auth verified working (80-char CRON_SECRET)

🤖 Generated with [Claude Code](https://claude.com/claude-code)