### PR TITLE
fix: Form 4 ownership display — previousStake, NaN%, award subtypes, vesting, indirect ownership

### DIFF
--- a/__tests__/regression/form4-ai-schema-classification.test.ts
+++ b/__tests__/regression/form4-ai-schema-classification.test.ts
@@ -427,8 +427,8 @@ describe('Form 4: AI Schema → Template Classification', () => {
       });
       const result = parseResponse(aiResponse, '4');
       const data = result.data as Record<string, unknown>;
-      // Code A + $0 price = derivative grant → suffix is "derivative securities"
-      expect(data.previousStake).toBe('100000 shares'); // 150000 - 50000 (previousStake always uses "shares")
+      // Code A + $0 price = derivative grant → suffix matches newStake
+      expect(data.previousStake).toBe('100000 derivative securities'); // 150000 - 50000
       expect(data.newStake).toBe('150000 derivative securities');
     });
 

--- a/components/ui/email/templates/form4-minimalist-template.tsx
+++ b/components/ui/email/templates/form4-minimalist-template.tsx
@@ -24,6 +24,10 @@ interface TransactionData {
   acquisitionDisposition?: string;
   code?: string;
   date?: string;
+  sharesOwnedFollowing?: string | number;
+  securityType?: string;
+  ownershipForm?: string;
+  ownershipNature?: string;
 }
 
 /**
@@ -291,17 +295,19 @@ interface AggregatedTransaction {
   // SEC transaction code (only populated for single transactions)
   code?: string;
   codeDescription?: string;
+  // Security types from underlying transactions
+  securityTypes: string[];
 }
 
 export function aggregateTransactionsByType(transactions: TransactionData[]): AggregatedTransaction[] {
-  const groups: Record<string, { shares: number; value: number; count: number; prices: number[]; codes: string[] }> = {
-    gift: { shares: 0, value: 0, count: 0, prices: [], codes: [] },
-    sale: { shares: 0, value: 0, count: 0, prices: [], codes: [] },
-    purchase: { shares: 0, value: 0, count: 0, prices: [], codes: [] },
-    transfer: { shares: 0, value: 0, count: 0, prices: [], codes: [] },
-    award: { shares: 0, value: 0, count: 0, prices: [], codes: [] },
-    exercise: { shares: 0, value: 0, count: 0, prices: [], codes: [] },
-    other: { shares: 0, value: 0, count: 0, prices: [], codes: [] },
+  const groups: Record<string, { shares: number; value: number; count: number; prices: number[]; codes: string[]; securityTypes: string[] }> = {
+    gift: { shares: 0, value: 0, count: 0, prices: [], codes: [], securityTypes: [] },
+    sale: { shares: 0, value: 0, count: 0, prices: [], codes: [], securityTypes: [] },
+    purchase: { shares: 0, value: 0, count: 0, prices: [], codes: [], securityTypes: [] },
+    transfer: { shares: 0, value: 0, count: 0, prices: [], codes: [], securityTypes: [] },
+    award: { shares: 0, value: 0, count: 0, prices: [], codes: [], securityTypes: [] },
+    exercise: { shares: 0, value: 0, count: 0, prices: [], codes: [], securityTypes: [] },
+    other: { shares: 0, value: 0, count: 0, prices: [], codes: [], securityTypes: [] },
   };
 
   for (const tx of transactions) {
@@ -347,6 +353,7 @@ export function aggregateTransactionsByType(transactions: TransactionData[]): Ag
     groups[groupKey].count += 1;
     if (price > 0) groups[groupKey].prices.push(price);
     if (tx.code) groups[groupKey].codes.push(tx.code);
+    if (tx.securityType) groups[groupKey].securityTypes.push(tx.securityType);
   }
 
   // Format and return non-empty groups
@@ -371,6 +378,7 @@ export function aggregateTransactionsByType(transactions: TransactionData[]): Ag
         priceDisplay: avgPrice > 0 ? `$${avgPrice.toFixed(2)}` : '$0',
         code: primaryCode,
         codeDescription: primaryCode ? getTransactionCodeDescription(primaryCode) : undefined,
+        securityTypes: data.securityTypes,
       });
     }
   }
@@ -388,6 +396,39 @@ function formatAggregatedValue(value: number): string {
   if (value >= 1000) return `$${(value / 1000).toFixed(0)}K`;
   if (value > 0) return `$${value.toFixed(0)}`;
   return '$0';
+}
+
+function getAwardSubtitle(aggTx: AggregatedTransaction): string {
+  const types = aggTx.securityTypes || [];
+  const joined = types.join(' ').toLowerCase();
+  if (joined.includes('stock option') || joined.includes('right to buy')) {
+    return aggTx.avgPrice > 0 ? `Stock options @ ${aggTx.priceDisplay}` : 'Stock options';
+  }
+  if (joined.includes('restricted stock') || joined.includes('rsu')) return 'Restricted Stock Units';
+  if (joined.includes('performance') || joined.includes('psu')) return 'Performance Stock Units';
+  return 'Equity compensation';
+}
+
+function getOwnershipBreakdown(transactions: TransactionData[]): { form: string; nature: string; shares: string }[] | null {
+  const groups = new Map<string, string>();
+  for (const tx of transactions) {
+    const form = tx.ownershipForm || 'D';
+    const nature = tx.ownershipNature || '';
+    const key = `${form}:${nature}`;
+    const sof = tx.sharesOwnedFollowing;
+    if (sof) groups.set(key, String(sof));
+  }
+  if (groups.size <= 1) return null; // All same form, use simple display
+  const result: { form: string; nature: string; shares: string }[] = [];
+  for (const [key, shares] of groups.entries()) {
+    const [form, nature] = key.split(':');
+    result.push({
+      form: form === 'I' ? 'Indirect' : 'Direct',
+      nature,
+      shares: parseFloat(shares.replace(/,/g, '')).toLocaleString(),
+    });
+  }
+  return result.slice(0, 3); // Cap at 3 entities
 }
 
 /**
@@ -644,6 +685,9 @@ export function Form4MinimalistTemplate({ filing }: Form4MinimalistTemplateProps
     sharesOwnedFollowing: t.sharesOwnedFollowing !== undefined ? String(t.sharesOwnedFollowing) : undefined,
     acquisitionDisposition: t.acquisitionDisposition,
     date: t.date,
+    securityType: t.securityType,
+    ownershipForm: t.ownershipForm,
+    ownershipNature: t.ownershipNature,
   }));
   const extractedTransactions = hasExtractedData ? extractedData.transactions.map(t => ({
     type: t.type,
@@ -875,7 +919,7 @@ export function Form4MinimalistTemplate({ filing }: Form4MinimalistTemplateProps
                                             marginTop: '4px',
                                           }}>
                                             {aggTx.totalValue === 0
-                                              ? (aggTx.type === 'award' ? 'Equity compensation' : aggTx.type === 'gift' || aggTx.type === 'transfer' ? 'No monetary value' : `${aggTx.sharesDisplay} shares`)
+                                              ? (aggTx.type === 'award' ? getAwardSubtitle(aggTx) : aggTx.type === 'gift' || aggTx.type === 'transfer' ? 'No monetary value' : `${aggTx.sharesDisplay} shares`)
                                               : `${aggTx.sharesDisplay} shares${aggTx.avgPrice > 0 ? ` @ ${aggTx.priceDisplay}` : ''}`}
                                           </div>
                                           {/* SEC transaction code description for single transactions */}
@@ -980,7 +1024,7 @@ export function Form4MinimalistTemplate({ filing }: Form4MinimalistTemplateProps
                 // Parse percentage for color logic (handles "-10.00%", "50.00%", "+5.0%")
                 const pctNum = parseFloat((percentChange || '0').replace(/[%+]/g, ''));
                 const pctColor = pctNum < 0 ? '#DC2626' : pctNum > 0 ? '#16A34A' : EmailColors.text.meta;
-                const pctDisplay = percentChange
+                const pctDisplay = percentChange && !percentChange.includes('NaN')
                   ? (pctNum > 0 && !percentChange.startsWith('+') ? `+${percentChange}` : percentChange)
                   : '';
 
@@ -1004,6 +1048,32 @@ export function Form4MinimalistTemplate({ filing }: Form4MinimalistTemplateProps
                         }}>
                           {previousStake && newStake ? 'Ownership Impact' : 'Current Holdings'}
                         </div>
+                        {/* Ownership breakdown for mixed direct/indirect */}
+                        {(() => {
+                          const breakdown = getOwnershipBreakdown(transactions);
+                          if (breakdown) {
+                            return (
+                              <div style={{ marginBottom: '8px' }}>
+                                {breakdown.map((b, i) => (
+                                  <div key={i} style={{
+                                    fontSize: '13px',
+                                    color: EmailColors.text.body,
+                                    padding: '2px 0',
+                                  }}>
+                                    <span style={{ fontWeight: 600 }}>{b.form}{b.nature ? ` (${b.nature})` : ''}:</span>{' '}
+                                    {b.shares} shares
+                                  </div>
+                                ))}
+                                {transactions.length > 3 && transactions.some((t) => t.ownershipForm) && (
+                                  <div style={{ fontSize: '11px', color: EmailColors.text.muted, marginTop: '2px' }}>
+                                    and more entities in filing
+                                  </div>
+                                )}
+                              </div>
+                            );
+                          }
+                          return null;
+                        })()}
                         <div>
                           {previousStake && newStake ? (
                             <>
@@ -1089,6 +1159,40 @@ export function Form4MinimalistTemplate({ filing }: Form4MinimalistTemplateProps
                         }}
                         dangerouslySetInnerHTML={{ __html: markdownToHtml(headline) }}
                       />
+                    </tr>
+                  </tbody>
+                </table>
+              )}
+
+              {/* Vesting Details - shown when vesting schedule is available */}
+              {normalizedData?.vestingDetails && (
+                <table width="100%" cellPadding="0" cellSpacing="0" style={{ marginBottom: '16px' }}>
+                  <tbody>
+                    <tr>
+                      <td style={{
+                        padding: '12px 16px',
+                        backgroundColor: '#EFF6FF',
+                        borderRadius: '8px',
+                        border: '1px solid #BFDBFE',
+                      }}>
+                        <div style={{
+                          fontSize: '11px',
+                          fontWeight: 700,
+                          color: '#1E40AF',
+                          textTransform: 'uppercase' as const,
+                          letterSpacing: '0.5px',
+                          marginBottom: '4px',
+                        }}>
+                          Vesting Schedule
+                        </div>
+                        <div style={{
+                          fontSize: '13px',
+                          color: '#1E3A5F',
+                          lineHeight: '1.4',
+                        }}>
+                          {normalizedData.vestingDetails}
+                        </div>
+                      </td>
                     </tr>
                   </tbody>
                 </table>

--- a/lib/ai/parsers/response-parser.ts
+++ b/lib/ai/parsers/response-parser.ts
@@ -19,6 +19,8 @@ import {
   parseStringTransaction as centralParseStringTx,
   isCharacterIndexedObject,
   CURRENT_FORM4_SCHEMA_VERSION,
+  derivePreviousStake,
+  NormalizedTransaction,
 } from '../../email/form4-field-normalizer';
 
 /**
@@ -222,39 +224,33 @@ function normalizeFields(data: unknown, filingType: SECFilingType): unknown {
         }
       }
 
-      // Derive previousStake from first transaction's sharesOwnedFollowing + shares
+      // Derive previousStake using shared first-chronological algorithm
       if (!normalized.previousStake && normalized.newStake && Array.isArray(normalized.transactions)) {
-        const txArr = normalized.transactions as Record<string, unknown>[];
-        // Find first transaction with sharesOwnedFollowing
-        for (let i = 0; i < txArr.length; i++) {
-          const sof = txArr[i].sharesOwnedFollowing;
-          if (sof && String(sof).trim()) {
-            const sofCleaned = parseFloat(String(sof).replace(/[$,\[\]]/g, '').trim());
-            const txShares = parseFloat(String(txArr[i].shares || '0').replace(/[$,\[\]]/g, '').trim());
-            if (!isNaN(sofCleaned) && !isNaN(txShares) && txShares > 0) {
-              const ad = String(txArr[i].acquisitionDisposition || '').toUpperCase();
-              const code = String(txArr[i].code || '').toUpperCase();
-              // Disposition: shares were removed → before = after + shares
-              // Acquisition: shares were added → before = after - shares
-              const isDisposition = ad === 'D' || code === 'S' || code === 'D' || code === 'G' || code === 'F';
-              const previousNum = isDisposition ? sofCleaned + txShares : sofCleaned - txShares;
-              if (previousNum > 0) {
-                normalized.previousStake = `${Math.round(previousNum)} shares`;
-              }
-              break;
-            }
-          }
+        const txArr = normalized.transactions as NormalizedTransaction[];
+        const prevNum = derivePreviousStake(txArr);
+        if (prevNum !== null) {
+          // Use same suffix as newStake (shares vs derivative securities)
+          const suffix = String(normalized.newStake).includes('derivative securities')
+            ? 'derivative securities' : 'shares';
+          normalized.previousStake = `${prevNum} ${suffix}`;
         }
       }
 
       // Derive percentageChange from previousStake and newStake
       if (!normalized.percentageChange && normalized.previousStake && normalized.newStake) {
-        const prevNum = parseFloat(String(normalized.previousStake).replace(/[^0-9.]/g, ''));
-        const newNum = parseFloat(String(normalized.newStake).replace(/[^0-9.]/g, ''));
-        if (!isNaN(prevNum) && !isNaN(newNum) && prevNum > 0) {
-          const pctChange = ((newNum - prevNum) / prevNum) * 100;
-          const sign = pctChange >= 0 ? '+' : '';
-          normalized.percentageChange = `${sign}${pctChange.toFixed(1)}%`;
+        // Skip % calc when comparing different security types (shares vs derivative securities)
+        const prevStr = String(normalized.previousStake);
+        const newStr = String(normalized.newStake);
+        const prevIsDerivative = prevStr.includes('derivative');
+        const newIsDerivative = newStr.includes('derivative');
+        if (prevIsDerivative === newIsDerivative) {
+          const prevNum = parseFloat(prevStr.replace(/[^0-9.]/g, ''));
+          const newNum = parseFloat(newStr.replace(/[^0-9.]/g, ''));
+          if (!isNaN(prevNum) && !isNaN(newNum) && isFinite(prevNum) && prevNum > 0) {
+            const pctChange = ((newNum - prevNum) / prevNum) * 100;
+            const sign = pctChange >= 0 ? '+' : '';
+            normalized.percentageChange = `${sign}${pctChange.toFixed(1)}%`;
+          }
         }
       }
 

--- a/lib/ai/prompts/unified-prompts.ts
+++ b/lib/ai/prompts/unified-prompts.ts
@@ -342,7 +342,10 @@ export const FORM_SCHEMAS: Record<string, JSONSchema> = {
             pricePerShare: { type: 'string', description: 'REQUIRED: Price per share with $ from column 4 - if $0, check if this is a gift/grant. Never leave blank.' },
             date: { type: 'string', description: 'Transaction date from column 2 (YYYY-MM-DD)' },
             acquisitionDisposition: { type: 'string', description: 'A for acquired, D for disposed' },
-            sharesOwnedFollowing: { type: 'string', description: 'Amount of Securities Beneficially Owned Following Reported Transaction. For Table I use Column 5 (shares of common stock). For Table II use Column 11 (derivative securities remaining, e.g., stock options). Total shares/securities held after this transaction.' }
+            sharesOwnedFollowing: { type: 'string', description: 'Amount of Securities Beneficially Owned Following Reported Transaction. For Table I use Column 5 (shares of common stock). For Table II use Column 11 (derivative securities remaining, e.g., stock options). Total shares/securities held after this transaction.' },
+            securityType: { type: 'string', description: 'Security type exactly from filing table header: "Common Stock", "Stock Option (Right to Buy)", "Restricted Stock Unit", "Performance Stock Unit". Copy verbatim from the Title of Security column.' },
+            ownershipForm: { type: 'string', description: 'D for Direct, I for Indirect ownership. From Column 7 of Table I or Table II.' },
+            ownershipNature: { type: 'string', description: 'Nature of indirect ownership (e.g., "By Family Trust", "By LLC", "By Spouse"). From Column 8. Only populate for indirect ownership.' }
           },
           required: ['code', 'type', 'shares', 'pricePerShare', 'sharesOwnedFollowing']
         }
@@ -365,6 +368,11 @@ export const FORM_SCHEMAS: Record<string, JSONSchema> = {
       has10b51Plan: {
         type: 'boolean',
         description: 'CRITICAL: Check footnotes/explanations for 10b5-1 trading plan. Set true if: "pursuant to a 10b5-1", "pre-arranged trading plan", "Rule 10b5-1", "prearranged trading agreement". Set false if: "no 10b5-1", "not pursuant to", or no mention.'
+      },
+      vestingDetails: {
+        type: 'string',
+        description: 'Vesting schedule from footnotes if present (e.g., "25% vests annually starting March 15, 2026"). Include plan name and key dates. Empty string if no vesting info found.',
+        maxLength: 300
       }
     }
   },
@@ -1037,6 +1045,9 @@ const FORM_EXTRACTION_GUIDANCE: Record<string, string> = {
   * If checkbox marked OR language found = has10b51Plan: true
   * If no checkbox/mention = has10b51Plan: false
 - FOOTNOTES ARE CRITICAL: Often contain essential context about the transaction (vesting schedules, plan details, related transactions)
+- SECURITY TYPE: Copy the security type verbatim from the "Title of Security" column in Table I or Table II (e.g., "Class A Common Stock", "Stock Option (Right to Buy)", "Restricted Stock Unit"). Put in securityType field for each transaction.
+- OWNERSHIP FORM: Column 7 indicates Direct (D) or Indirect (I) ownership. Column 8 shows the nature of indirect ownership (e.g., "By Family Trust", "By LLC"). Extract ownershipForm and ownershipNature for every transaction.
+- VESTING DETAILS: Check footnotes for vesting schedules. Look for "vesting schedule", "vest", "annual installments", "quarterly vesting", specific dates. Populate vestingDetails with a concise schedule summary. Leave empty if no vesting info found.
 - **CRITICAL** POST-TRANSACTION OWNERSHIP — sharesOwnedFollowing is REQUIRED for EVERY transaction:
   * You MUST populate sharesOwnedFollowing on every transaction object. This field drives the ownership change display.
   * Table I (Non-Derivative): Extract from Column 5 — total shares of common stock remaining after this transaction

--- a/lib/email/form4-field-normalizer.ts
+++ b/lib/email/form4-field-normalizer.ts
@@ -37,6 +37,9 @@ export interface NormalizedTransaction {
   sharesOwnedFollowing?: string | number;
   acquisitionDisposition?: string;
   date?: string;
+  securityType?: string;
+  ownershipForm?: string;
+  ownershipNature?: string;
 }
 
 /**
@@ -55,6 +58,7 @@ export interface NormalizedForm4Data {
   percentageChange?: string;
   newStake?: string;
   previousStake?: string;
+  vestingDetails?: string;
 }
 
 /**
@@ -67,7 +71,7 @@ export interface NormalizedForm4Data {
 
 // Bump when changing field mappings or normalizer behavior.
 // Used by response-parser (stamp) and summarize-cached-handler (detect stale data).
-export const CURRENT_FORM4_SCHEMA_VERSION = 2;
+export const CURRENT_FORM4_SCHEMA_VERSION = 3;
 
 export const TX_CODE_TO_TYPE: Record<string, string> = {
   'P': 'Purchase',
@@ -229,11 +233,11 @@ function buildKnownFieldSet(aliases: Record<string, string[]>): Set<string> {
 
 const KNOWN_TX_FIELDS = buildKnownFieldSet(TRANSACTION_FIELD_ALIASES);
 // Add extra fields the AI returns that we intentionally ignore
-['table', 'security', 'footnote', 'footnotes', 'ownershipForm', 'nature'].forEach(f => KNOWN_TX_FIELDS.add(f));
+['table', 'security', 'footnote', 'footnotes', 'ownershipForm', 'ownershipNature', 'nature', 'securityType', 'tableSource'].forEach(f => KNOWN_TX_FIELDS.add(f));
 
 const KNOWN_FORM4_FIELDS = buildKnownFieldSet(FORM4_FIELD_ALIASES);
 // Add fields that are always present and don't need aliasing
-['company', 'summary', 'filingDate', 'has10b51Plan', 'transactions', 'signalStrength', 'filingType'].forEach(f => KNOWN_FORM4_FIELDS.add(f));
+['company', 'summary', 'filingDate', 'has10b51Plan', 'transactions', 'signalStrength', 'filingType', 'vestingDetails'].forEach(f => KNOWN_FORM4_FIELDS.add(f));
 
 /**
  * Normalize a single transaction object from AI output.
@@ -306,6 +310,11 @@ export function normalizeTransaction(raw: unknown): NormalizedTransaction | null
   // Audit unexpected fields
   auditUnexpectedFields(obj, KNOWN_TX_FIELDS, 'transaction');
 
+  // Extract new optional fields
+  const securityType = (obj.securityType as string) || '';
+  const ownershipFormVal = (obj.ownershipForm as string) || '';
+  const ownershipNature = (obj.ownershipNature as string) || '';
+
   const result: NormalizedTransaction = {
     code,
     type,
@@ -315,7 +324,51 @@ export function normalizeTransaction(raw: unknown): NormalizedTransaction | null
   if (cleanOwnership !== undefined) result.sharesOwnedFollowing = cleanOwnership as string | number;
   if (acquisitionDisposition) result.acquisitionDisposition = acquisitionDisposition;
   if (date) result.date = date;
+  if (securityType) result.securityType = securityType;
+  if (ownershipFormVal) result.ownershipForm = ownershipFormVal;
+  if (ownershipNature) result.ownershipNature = ownershipNature;
   return result;
+}
+
+/**
+ * Derive previousStake from transactions using first-chronological approach.
+ *
+ * Sort transactions by date (if available), take the FIRST transaction,
+ * and derive the position BEFORE that transaction:
+ *   - Disposition (S, D, G, F): before = sharesOwnedFollowing + shares
+ *   - Acquisition (A, P, J, M): before = sharesOwnedFollowing - shares
+ *
+ * This is the shared algorithm used by both response-parser and normalizer.
+ */
+export function derivePreviousStake(transactions: NormalizedTransaction[]): number | null {
+  if (transactions.length === 0) return null;
+
+  // Sort by date if available, otherwise preserve array order (filing order)
+  const sorted = [...transactions].sort((a, b) => {
+    if (a.date && b.date) return a.date.localeCompare(b.date);
+    return 0;
+  });
+
+  // Find first transaction with valid sharesOwnedFollowing
+  for (const tx of sorted) {
+    const sof = parseFloat(String(tx.sharesOwnedFollowing || '').replace(/[$,\[\]]/g, ''));
+    const shares = parseFloat(String(tx.shares || '').replace(/[$,\[\]]/g, ''));
+    if (isNaN(sof) || isNaN(shares) || shares <= 0) continue;
+
+    const code = (tx.code || '').toUpperCase();
+    const ad = (tx.acquisitionDisposition || '').toUpperCase();
+    const isDisposition = ad === 'D' || code === 'S' || code === 'D' || code === 'G' || code === 'F';
+    const before = isDisposition ? sof + shares : sof - shares;
+
+    if (before > 0) {
+      componentLogger.debug('Derived previousStake from first-chronological transaction', {
+        code, shares, sof, before, date: tx.date,
+      });
+      return Math.round(before);
+    }
+    return null;
+  }
+  return null;
 }
 
 /**
@@ -370,22 +423,11 @@ export function normalizeForm4Data(summaryJSON: Record<string, unknown> | null |
     }
   }
 
-  // Derive previousStake from first transaction
+  // Derive previousStake using shared first-chronological algorithm
   if (!previousStake && transactions.length > 0 && newStake) {
-    const firstTx = transactions[0];
-    const sof = firstTx.sharesOwnedFollowing;
-    const sharesNum = parseFloat(String(firstTx.shares).replace(/,/g, ''));
-    const sofNum = parseFloat(String(sof).replace(/,/g, ''));
-
-    if (!isNaN(sharesNum) && !isNaN(sofNum)) {
-      const code = firstTx.code?.toUpperCase();
-      const ad = firstTx.acquisitionDisposition?.toUpperCase();
-      const isDisposition = ad === 'D' || code === 'S' || code === 'D' || code === 'G' || code === 'F';
-
-      const prevNum = isDisposition ? sofNum + sharesNum : sofNum - sharesNum;
-      if (prevNum > 0) {
-        previousStake = formatNumberWithCommas(prevNum);
-      }
+    const prevNum = derivePreviousStake(transactions);
+    if (prevNum !== null) {
+      previousStake = formatNumberWithCommas(prevNum);
     }
   }
 
@@ -420,6 +462,9 @@ export function normalizeForm4Data(summaryJSON: Record<string, unknown> | null |
   // Audit unexpected top-level fields
   auditUnexpectedFields(summaryJSON, KNOWN_FORM4_FIELDS, 'form4-top-level');
 
+  // Extract vestingDetails
+  const vestingDetails = (summaryJSON.vestingDetails as string) || undefined;
+
   return {
     company: (summaryJSON.company as string) || '',
     summary: (summaryJSON.summary as string) || '',
@@ -433,6 +478,7 @@ export function normalizeForm4Data(summaryJSON: Record<string, unknown> | null |
     percentageChange,
     newStake,
     previousStake,
+    vestingDetails: vestingDetails ? vestingDetails.substring(0, 300) : undefined,
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes 3 Form 4 email bugs reported on META insider filings (Olivan Javier, Susan J. Li, Aaron Anderson) plus adds vesting details and indirect ownership support.

**Bug Fixes:**
- **Inverted ownership impact**: previousStake derivation now uses first-chronological algorithm instead of first-array-element. Fixes filings where awards appear before sales in the transaction array, which caused pre-transaction position to appear smaller than post-transaction position.
- **NaN% in current holdings**: Defense-in-depth NaN guard at 3 levels (derivation, calculation, display). Also skips percentage calculation when comparing shares vs derivative securities (suffix mismatch).
- **Generic "Equity compensation" label**: Award cards now show security-type-aware subtitles ("Restricted Stock Units", "Stock options @ $X", "Performance Stock Units").

**New Features:**
- **Vesting details card**: Extracts vesting schedules from footnotes via AI prompt. Displays blue info card when available.
- **Indirect ownership breakdown**: When transactions have mixed ownership forms (Direct + Indirect through LLC/Trust), shows a stacked breakdown capped at 3 entities.
- **securityType/ownershipForm/ownershipNature**: Added to AI schema for richer Form 4 data extraction.

**Architecture:**
- Extracted shared `derivePreviousStake()` function (DRY fix, was duplicated in response-parser and normalizer)
- Bumped `CURRENT_FORM4_SCHEMA_VERSION` to 3

## Test Coverage
- 247/247 Form 4 tests passing
- Zero new regressions (36 pre-existing failures on main confirmed)
- Updated 1 regression test to expect matching suffixes for derivative previousStake

## Pre-Landing Review
No issues found. No SQL changes, no auth boundaries, no user input handling.

## Plan Completion
Plan file: `.claude/tasks/form4-ownership-fixes.md`
- [DONE] Phase 1: Fix previousStake derivation + NaN guard
- [DONE] Phase 2: Separate award types in display
- [DONE] Phase 3: Add vesting details
- [DONE] Phase 4: Surface indirect beneficial ownership
- [DONE] Phase 5: Test updates

## Test plan
- [x] All Form 4 tests pass (247/247)
- [x] Lint clean (no ESLint warnings or errors)
- [x] Zero new regressions vs main

🤖 Generated with [Claude Code](https://claude.com/claude-code)