### PR TITLE
fix: skeleton card border mismatch and faster trial upgrade flow

### DIFF
--- a/app/subscribe/__tests__/loading.test.tsx
+++ b/app/subscribe/__tests__/loading.test.tsx
@@ -27,15 +27,15 @@ describe("SubscribeLoading", () => {
     expect(toggle).toBeInTheDocument();
   });
 
-  test("renders 3 plan card skeletons", () => {
+  test("renders 2 plan card skeletons matching actual plan count", () => {
     const { container } = render(<SubscribeLoading />);
     const cards = container.querySelectorAll('[data-testid="plan-card-skeleton"]');
-    expect(cards).toHaveLength(3);
+    expect(cards).toHaveLength(2);
   });
 
   test("uses responsive grid for plan cards", () => {
     const { container } = render(<SubscribeLoading />);
-    const grid = container.querySelector(".md\\:grid-cols-3");
+    const grid = container.querySelector(".md\\:grid-cols-2");
     expect(grid).toBeInTheDocument();
   });
 

--- a/app/subscribe/loading.tsx
+++ b/app/subscribe/loading.tsx
@@ -31,15 +31,14 @@ export default function SubscribeLoading() {
         </div>
 
         {/* Plan Cards Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          {Array.from({ length: 3 }).map((_, i) => (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {Array.from({ length: 2 }).map((_, i) => (
             <div
               key={i}
               data-testid="plan-card-skeleton"
-              className="rounded-xl border p-6 space-y-4 animate-slideUp focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-blue-500"
+              className="landing-card space-y-4 animate-slideUp focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-blue-500"
               style={{
                 animationDelay: `${i * 100}ms`,
-                backgroundColor: "var(--landing-card-bg, white)",
               }}
               role="article"
               aria-label={`Loading pricing plan ${i + 1}`}

--- a/app/subscribe/page.tsx
+++ b/app/subscribe/page.tsx
@@ -273,7 +273,7 @@ function SubscribePageContent() {
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             {Array.from({ length: 2 }).map((_, i) => (
-              <div key={i} className="rounded-xl border p-6 space-y-4 animate-slideUp" style={{ animationDelay: `${i * 100}ms`, backgroundColor: 'var(--landing-card-bg, white)' }}>
+              <div key={i} className="landing-card space-y-4 animate-slideUp" style={{ animationDelay: `${i * 100}ms` }}>
                 <div className="flex items-center justify-between">
                   <div className="space-y-1"><Skeleton className="h-3 w-12" /><Skeleton className="h-7 w-24" /></div>
                   <Skeleton className="h-6 w-6 rounded" />
@@ -577,7 +577,7 @@ function SubscribePageLoading() {
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           {Array.from({ length: 2 }).map((_, i) => (
-            <div key={i} className="rounded-xl border p-6 space-y-4 animate-slideUp" style={{ animationDelay: `${i * 100}ms`, backgroundColor: 'var(--landing-card-bg, white)' }}>
+            <div key={i} className="landing-card space-y-4 animate-slideUp" style={{ animationDelay: `${i * 100}ms` }}>
               <div className="flex items-center justify-between">
                 <div className="space-y-1"><Skeleton className="h-3 w-12" /><Skeleton className="h-7 w-24" /></div>
                 <Skeleton className="h-6 w-6 rounded" />

--- a/components/dashboard/expired-trial-banner.tsx
+++ b/components/dashboard/expired-trial-banner.tsx
@@ -27,7 +27,7 @@ export function ExpiredTrialBanner() {
             className="bg-orange-600 hover:bg-orange-700"
           >
             <Link
-              href="/dashboard/billing"
+              href="/subscribe"
               className="flex items-center gap-2"
             >
               <CreditCard className="h-5 w-5" />


### PR DESCRIPTION
## Summary

- **Skeleton card styling**: Subscribe page skeleton cards now use the `landing-card` CSS class instead of raw Tailwind `border` + inline `backgroundColor`. This matches the actual pricing cards' border, background, border-radius, and shadow.
- **Card count fix**: `loading.tsx` showed 3 skeleton cards in a 3-column grid, but the page only renders 2 plans (PRO, MAX). Fixed to 2 cards in 2-column grid, eliminating layout shift (CLS) when content loads.
- **Faster upgrade flow**: Expired trial "Upgrade Now" CTA now links directly to `/subscribe` instead of going through `/dashboard/billing` first. Trial users on the billing page just saw a single "Upgrade Plan" button linking to `/subscribe` anyway, so this skips the unnecessary intermediate page load.

## Test Coverage
No new application code paths — CSS class swaps, href change, and test assertion updates.

## Pre-Landing Review
Pre-Landing Review: No issues found. (ran via /autoplan + /review + /ship)

## Design Review
Design Review (lite): 0 findings. AI Slop: clean.

## Plan Completion
Plan: `/Users/wilf/.claude/plans/memoized-kindling-sunset.md`
5/5 DONE — all plan items implemented.

## Test plan
- [x] Related tests pass (18 tests, 0 failures)
- [x] `npm run build` passes
- [x] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)