### PR TITLE
fix: remove Trial tier from landing page, show 2-tier pricing (Pro + Max)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,4 @@ test-tesla-filing-extraction.js
 
 # MCP servers (cloned repos)
 /mcp-send-email/
+.gstack/

--- a/__tests__/components/landing/landing-page-auth.test.tsx
+++ b/__tests__/components/landing/landing-page-auth.test.tsx
@@ -128,7 +128,7 @@ describe('Landing Page Auth-Aware Integration', () => {
   // Pricing Section with subscription context
   // ===========================================================
   describe('PricingSectionV2 personalized behavior', () => {
-    it('Scenario 1: unauthenticated - all CTAs show "Get Started"', () => {
+    it('Scenario 1: unauthenticated - all CTAs show "Start Free Trial"', () => {
       mockUseAuth.mockReturnValue(authStates.unauthenticated);
       mockUseSubscriptionContext.mockReturnValue(
         makeSubscriptionContext(subscriptionFixtures.noSubscription)
@@ -137,11 +137,11 @@ describe('Landing Page Auth-Aware Integration', () => {
       render(<PricingSectionV2 />);
 
       const buttons = screen.getAllByRole('button');
-      const getStartedButtons = buttons.filter(
-        (btn) => btn.textContent?.includes('Get Started')
+      const trialButtons = buttons.filter(
+        (btn) => btn.textContent?.includes('Start Free Trial')
       );
-      // All 3 plans should show "Get Started" for unauthenticated
-      expect(getStartedButtons.length).toBe(3);
+      // 2 plans (Pro + Max) should show "Start Free Trial" for unauthenticated
+      expect(trialButtons.length).toBe(2);
     });
 
     it('Scenario 2: authenticated not onboarded - CTAs show "Complete Setup"', () => {
@@ -156,10 +156,10 @@ describe('Landing Page Auth-Aware Integration', () => {
       const setupButtons = buttons.filter(
         (btn) => btn.textContent?.includes('Complete Setup')
       );
-      expect(setupButtons.length).toBe(3);
+      expect(setupButtons.length).toBe(2);
     });
 
-    it('Scenario 3: FREE trial active - FREE shows "Current Plan" badge', () => {
+    it('Scenario 3: FREE trial active - no "Current Plan" badge (FREE card removed)', () => {
       mockUseAuth.mockReturnValue(authStates.authenticatedOnboarded);
       mockUseSubscriptionContext.mockReturnValue(
         makeSubscriptionContext(subscriptionFixtures.freeTrialActive)
@@ -167,13 +167,8 @@ describe('Landing Page Auth-Aware Integration', () => {
 
       render(<PricingSectionV2 />);
 
-      // FREE plan should have Current Plan badge
-      const statusBadge = screen.getByRole('status');
-      expect(statusBadge).toHaveTextContent('Current Plan');
-
-      // FREE plan button should be disabled
-      const currentPlanBtn = screen.getByRole('button', { name: /Current Plan/i });
-      expect(currentPlanBtn).toBeDisabled();
+      // FREE plan card no longer exists, so no "Current Plan" badge
+      expect(screen.queryByRole('status')).not.toBeInTheDocument();
 
       // PRO and MAX should have active upgrade CTAs
       expect(screen.getByRole('button', { name: /Upgrade to Pro/i })).toBeEnabled();
@@ -215,7 +210,7 @@ describe('Landing Page Auth-Aware Integration', () => {
       expect(currentPlanBtn).toBeDisabled();
     });
 
-    it('Scenario 6: grandfathered FREE - FREE shows "Current Plan" badge', () => {
+    it('Scenario 6: grandfathered FREE - no "Current Plan" badge (FREE card removed)', () => {
       mockUseAuth.mockReturnValue(authStates.authenticatedOnboarded);
       mockUseSubscriptionContext.mockReturnValue(
         makeSubscriptionContext(subscriptionFixtures.freeGrandfathered)
@@ -223,8 +218,8 @@ describe('Landing Page Auth-Aware Integration', () => {
 
       render(<PricingSectionV2 />);
 
-      const statusBadge = screen.getByRole('status');
-      expect(statusBadge).toHaveTextContent('Current Plan');
+      // FREE plan card no longer exists, so no "Current Plan" badge
+      expect(screen.queryByRole('status')).not.toBeInTheDocument();
     });
 
     it('shows error banner when subscription fetch fails', () => {
@@ -266,7 +261,7 @@ describe('Landing Page Auth-Aware Integration', () => {
         screen.queryByRole('button', { name: /Current Plan/i })
       ).not.toBeInTheDocument();
       expect(
-        screen.queryByRole('button', { name: /Get Started/i })
+        screen.queryByRole('button', { name: /Start Free Trial/i })
       ).not.toBeInTheDocument();
     });
   });

--- a/__tests__/components/landing/pricing-card.test.tsx
+++ b/__tests__/components/landing/pricing-card.test.tsx
@@ -11,42 +11,42 @@ jest.mock('lucide-react', () => ({
 }));
 
 // Default plan fixture
-const freePlan = {
-  key: 'FREE',
-  name: 'Trial',
-  monthlyPrice: 0,
-  annualPrice: 0,
-  description: 'Full access for 7 days',
-  features: ['**Unlimited** companies', 'Real-time email alerts'],
-  cta: 'Start Free Trial',
-  href: '/onboarding',
-  popular: false,
-  disabled: false,
-  icon: ({ className }: { className?: string }) => <span className={className}>icon</span>,
-};
-
-const proPlan = {
-  ...freePlan,
+const proPlanFixture = {
   key: 'PRO',
   name: 'Pro',
   monthlyPrice: 199,
   annualPrice: 1990,
-  features: ['**25** companies to track', 'Priority processing queue'],
+  description: 'Everything you need for serious investing',
+  features: ['**25** companies to track', 'Real-time email alerts'],
   cta: 'Upgrade to Pro',
   href: '/onboarding?plan=pro',
   popular: true,
+  disabled: false,
+  icon: ({ className }: { className?: string }) => <span className={className}>icon</span>,
+};
+
+const maxPlan = {
+  ...proPlanFixture,
+  key: 'MAX',
+  name: 'Max',
+  monthlyPrice: 349,
+  annualPrice: 3490,
+  features: ['**Unlimited** companies', 'Dedicated support'],
+  cta: 'Upgrade to Max',
+  href: '/onboarding?plan=max',
+  popular: false,
 };
 
 const defaultProps = {
-  plan: freePlan,
+  plan: proPlanFixture,
   billingInterval: 'monthly' as const,
   isCurrentPlan: false,
   isTrialEndingSoon: false,
   loading: false,
   checkoutLoading: false,
   onCheckout: jest.fn(),
-  getCtaText: (plan: typeof freePlan) => plan.cta,
-  getPrice: (plan: typeof freePlan) => plan.monthlyPrice,
+  getCtaText: (plan: typeof proPlanFixture) => plan.cta,
+  getPrice: (plan: typeof proPlanFixture) => plan.monthlyPrice,
   getMonthlyEquivalent: () => null,
   getSavings: () => null,
 };
@@ -59,8 +59,8 @@ describe('PricingCard', () => {
   it('renders plan name, price, and features', () => {
     render(<PricingCard {...defaultProps} />);
 
-    expect(screen.getByRole('heading', { level: 3, name: /Trial/i })).toBeInTheDocument();
-    expect(screen.getByText('Unlimited')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3, name: /Pro/i })).toBeInTheDocument();
+    expect(screen.getByText('25')).toBeInTheDocument();
     expect(screen.getByText('Real-time email alerts')).toBeInTheDocument();
   });
 
@@ -121,14 +121,14 @@ describe('PricingCard', () => {
   });
 
   it('shows "Popular" badge for popular plans', () => {
-    render(<PricingCard {...defaultProps} plan={proPlan} />);
+    render(<PricingCard {...defaultProps} />);
 
     expect(screen.getByText('Popular')).toBeInTheDocument();
   });
 
   it('shows both Popular and Current Plan badges', () => {
     render(
-      <PricingCard {...defaultProps} plan={proPlan} isCurrentPlan={true} />
+      <PricingCard {...defaultProps} isCurrentPlan={true} />
     );
 
     expect(screen.getByText('Popular')).toBeInTheDocument();
@@ -149,20 +149,26 @@ describe('PricingCard', () => {
     const button = screen.getByRole('button');
     fireEvent.click(button);
 
-    expect(onCheckout).toHaveBeenCalledWith('FREE');
+    expect(onCheckout).toHaveBeenCalledWith('PRO');
   });
 
   it('renders bold text within features using **markdown** syntax', () => {
-    render(<PricingCard {...defaultProps} plan={proPlan} />);
+    render(<PricingCard {...defaultProps} />);
 
     // Bold text should be in a <strong> element
     const strongElement = screen.getByText('25');
     expect(strongElement.tagName).toBe('STRONG');
   });
 
-  it('shows "Everything in Trial" footer for PRO plan', () => {
-    render(<PricingCard {...defaultProps} plan={proPlan} />);
+  it('shows "Everything in Pro" footer for MAX plan', () => {
+    render(<PricingCard {...defaultProps} plan={maxPlan} />);
 
-    expect(screen.getByText('Everything in Trial')).toBeInTheDocument();
+    expect(screen.getByText('Everything in Pro')).toBeInTheDocument();
+  });
+
+  it('does not show "Everything in" footer for PRO plan', () => {
+    render(<PricingCard {...defaultProps} />);
+
+    expect(screen.queryByText(/Everything in/)).not.toBeInTheDocument();
   });
 });

--- a/__tests__/components/landing/pricing-section-v2.test.tsx
+++ b/__tests__/components/landing/pricing-section-v2.test.tsx
@@ -50,19 +50,17 @@ describe('PricingSectionV2', () => {
     expect(screen.getByText(/Simple, Transparent Pricing/i)).toBeInTheDocument();
   });
 
-  it('should render 3 pricing tiers', () => {
+  it('should render 2 pricing tiers (Pro and Max)', () => {
     render(<PricingSectionV2 />);
     const tierHeadings = screen.getAllByRole('heading', { level: 3 });
     const tierNames = tierHeadings.map((h) => h.textContent);
-    expect(tierNames).toContain('Trial');
     expect(tierNames).toContain('Pro');
     expect(tierNames).toContain('Max');
+    expect(tierNames).not.toContain('Trial');
   });
 
   it('should display prices for all tiers', () => {
     render(<PricingSectionV2 />);
-    // Trial tier shows "Free" price text
-    expect(screen.getByText('Free', { selector: 'span' })).toBeInTheDocument();
     // PRO tier shows $199
     expect(screen.getByText('$199')).toBeInTheDocument();
     // MAX tier shows $349
@@ -93,17 +91,17 @@ describe('PricingSectionV2', () => {
 
   it('should display feature lists for each tier', () => {
     render(<PricingSectionV2 />);
-    // Trial tier now shows unlimited companies
-    expect(screen.getAllByText(/Unlimited/i).length).toBeGreaterThanOrEqual(2); // Trial + Max both have unlimited
+    // Only MAX has unlimited companies now
+    expect(screen.getAllByText(/Unlimited/i).length).toBeGreaterThanOrEqual(1);
     // PRO: "25" in bold (rendered within <strong>)
     expect(screen.getByText('25')).toBeInTheDocument();
   });
 
-  it('should have CTA buttons for each tier (unauthenticated shows "Get Started")', () => {
+  it('should have CTA buttons for each tier (unauthenticated shows "Start Free Trial")', () => {
     render(<PricingSectionV2 />);
     const buttons = screen.getAllByRole('button').filter(
-      (btn) => btn.textContent?.includes('Get Started')
+      (btn) => btn.textContent?.includes('Start Free Trial')
     );
-    expect(buttons.length).toBe(3);
+    expect(buttons.length).toBe(2);
   });
 });

--- a/__tests__/config/stripe-pricing.test.ts
+++ b/__tests__/config/stripe-pricing.test.ts
@@ -1,7 +1,7 @@
 import { SUBSCRIPTION_PLANS, getPlanConfig, calculateSavingsPercentage } from '@/lib/stripe';
 
 describe('Stripe Pricing Configuration', () => {
-  describe('Free (Trial) Tier', () => {
+  describe('Free Tier', () => {
     it('should have $0 price and unlimited ticker limit', () => {
       const plan = getPlanConfig('FREE');
       expect(plan).toBeDefined();
@@ -9,9 +9,9 @@ describe('Stripe Pricing Configuration', () => {
       expect(plan?.tickerLimit).toBe(-1);
     });
 
-    it('should be named Trial', () => {
+    it('should be named Free', () => {
       const plan = getPlanConfig('FREE');
-      expect(plan?.name).toBe('Trial');
+      expect(plan?.name).toBe('Free');
     });
   });
 
@@ -113,7 +113,7 @@ describe('Stripe Pricing Configuration', () => {
   });
 
   describe('Plan Features', () => {
-    it('Free (Trial) tier should have ALL filing types', () => {
+    it('Free tier should have ALL filing types', () => {
       const plan = getPlanConfig('FREE');
       expect(plan?.filingTypes).toEqual(['ALL']);
     });
@@ -140,7 +140,7 @@ describe('Stripe Pricing Configuration', () => {
   });
 
   describe('Email Frequency', () => {
-    it('Free (Trial) tier should have realtime email frequency', () => {
+    it('Free tier should have realtime email frequency', () => {
       const plan = getPlanConfig('FREE');
       expect(plan?.emailFrequency).toBe('realtime');
     });

--- a/__tests__/integration/direct-checkout-flow.test.ts
+++ b/__tests__/integration/direct-checkout-flow.test.ts
@@ -51,7 +51,7 @@ jest.mock('@/lib/stripe', () => ({
     },
   },
   SUBSCRIPTION_PLANS: {
-    FREE: { name: 'Trial', monthlyPriceId: null, monthlyPrice: 0, tickerLimit: -1 },
+    FREE: { name: 'Free', monthlyPriceId: null, monthlyPrice: 0, tickerLimit: -1 },
     PRO: { name: 'Pro', monthlyPriceId: 'price_pro_monthly', monthlyPrice: 2900, tickerLimit: 25 },
     MAX: { name: 'Max', monthlyPriceId: 'price_max_monthly', monthlyPrice: 9900, tickerLimit: -1 },
   },

--- a/app/dashboard/billing/page.tsx
+++ b/app/dashboard/billing/page.tsx
@@ -146,11 +146,11 @@ export default function BillingPage() {
     if (subscription.isTrialing && subscription.daysRemaining > 0) {
       return `Trial — ${subscription.daysRemaining} ${subscription.daysRemaining === 1 ? 'day' : 'days'} remaining`;
     }
-    return 'Trial Expired — Upgrade to continue receiving summaries';
+    return 'Free Plan — Upgrade to continue receiving summaries';
   };
 
   const currentPrice = isFree
-    ? (getTrialStatusText() || 'Trial')
+    ? (getTrialStatusText() || 'Free')
     : currentPlanConfig
       ? `$${currentPlanConfig.monthlyPrice}/month`
       : 'Price unavailable';
@@ -198,7 +198,7 @@ export default function BillingPage() {
           <CardContent className="space-y-4">
             <div>
               <h3 className="font-semibold text-lg">
-                {isFree ? 'Trial' : (currentPlanConfig?.name || 'Unknown Plan')}
+                {isFree ? 'Free' : (currentPlanConfig?.name || 'Unknown Plan')}
               </h3>
               <p className="text-gray-600">
                 {currentPrice}

--- a/components/dashboard/dashboard-client.tsx
+++ b/components/dashboard/dashboard-client.tsx
@@ -393,7 +393,7 @@ export function DashboardClient({ showWelcome: _showWelcome = false, shouldMerge
               <h2 className="text-lg font-semibold">Tracked Tickers</h2>
               <p className="text-sm text-muted-foreground">
                 {!isUnlimited
-                  ? `${companies.length} / ${tickerLimit} tickers used on ${subscriptionTier === 'FREE' ? 'Trial' : subscriptionTier} plan`
+                  ? `${companies.length} / ${tickerLimit} tickers used on ${subscriptionTier === 'FREE' ? 'Free' : subscriptionTier} plan`
                   : "Manage your tracked companies."}
               </p>
             </div>

--- a/components/landing/pricing-card.tsx
+++ b/components/landing/pricing-card.tsx
@@ -63,7 +63,7 @@ export function PricingCard({
       <div className="flex items-center justify-between mb-4">
         <div>
           <p className="text-xs text-[var(--landing-text-muted)] uppercase tracking-wide mb-1">
-            {plan.key === 'FREE' ? 'Trial' : plan.name}
+            {plan.name}
           </p>
           <h3
             className="text-2xl font-bold"
@@ -96,42 +96,31 @@ export function PricingCard({
 
       {/* Price Display */}
       <div className="mb-6 h-[88px] flex flex-col justify-center">
-        {plan.monthlyPrice === 0 ? (
-          <div className="flex items-baseline gap-2">
-            <span
-              className="text-4xl font-bold"
-              style={{ color: 'var(--landing-secondary)' }}
-            >
-              Free
-            </span>
-            <span className="text-[var(--landing-text-muted)]">
-              for 7 days
-            </span>
-          </div>
-        ) : (
-          <>
-            <div className="flex items-baseline gap-2">
-              <span
-                className="text-4xl font-bold"
-                style={{ color: 'var(--landing-secondary)' }}
-              >
-                ${getPrice(plan)}
-              </span>
-              <span className="text-[var(--landing-text-muted)]">
-                /{billingInterval === 'annual' ? 'year' : 'month'}
-              </span>
-              {billingInterval === 'annual' && savings && (
-                <Badge className="bg-green-100 text-green-700 border-green-200 text-xs px-2 py-0.5">
-                  Save {savings}%
-                </Badge>
-              )}
-            </div>
-            {monthlyEquiv && (
-              <p className="text-xs text-[var(--landing-text-muted)] mt-1">
-                ${monthlyEquiv}/mo billed annually
-              </p>
-            )}
-          </>
+        <div className="flex items-baseline gap-2">
+          <span
+            className="text-4xl font-bold"
+            style={{ color: 'var(--landing-secondary)' }}
+          >
+            ${getPrice(plan)}
+          </span>
+          <span className="text-[var(--landing-text-muted)]">
+            /{billingInterval === 'annual' ? 'year' : 'month'}
+          </span>
+          {billingInterval === 'annual' && savings && (
+            <Badge className="bg-green-100 text-green-700 border-green-200 text-xs px-2 py-0.5">
+              Save {savings}%
+            </Badge>
+          )}
+        </div>
+        {monthlyEquiv && (
+          <p className="text-xs text-[var(--landing-text-muted)] mt-1">
+            ${monthlyEquiv}/mo billed annually
+          </p>
+        )}
+        {!isCurrentPlan && (
+          <p className="text-xs text-[var(--landing-text-muted)] mt-1">
+            7-day free trial included
+          </p>
         )}
       </div>
 
@@ -179,6 +168,11 @@ export function PricingCard({
             )}
           </Button>
         )}
+        {!loading && !isCurrentPlan && !plan.disabled && !isTrialEndingSoon && (
+          <p className="text-xs text-center text-[var(--landing-text-muted)] mt-2">
+            Cancel anytime. No charge until day 8.
+          </p>
+        )}
       </div>
 
       {/* Features List */}
@@ -206,14 +200,12 @@ export function PricingCard({
         })}
       </ul>
 
-      {/* "Everything in X" footer for higher tiers */}
-      {plan.key !== 'FREE' && (
+      {/* "Everything in Pro" footer for MAX tier */}
+      {plan.key === 'MAX' && (
         <div className="mt-4 pt-4 border-t border-gray-100">
           <div className="flex items-center gap-2 text-sm text-[var(--landing-text-muted)]">
             <span className="text-[var(--landing-primary)]">+</span>
-            <span>
-              Everything in {plan.key === 'PRO' ? 'Trial' : 'Pro'}
-            </span>
+            <span>Everything in Pro</span>
           </div>
         </div>
       )}

--- a/components/landing/sections-v2/pricing-section-v2.tsx
+++ b/components/landing/sections-v2/pricing-section-v2.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { motion } from 'framer-motion';
 import { useRouter } from 'next/navigation';
-import { Zap, Sparkles, Crown } from 'lucide-react';
+import { Sparkles, Crown } from 'lucide-react';
 import { toast } from 'sonner';
 import {
   staggerContainer,
@@ -23,19 +23,6 @@ import { PricingCard } from '@/components/landing/pricing-card';
  * Sourced from centralized Stripe config in lib/stripe.ts
  */
 const plans = [
-  {
-    key: 'FREE' as const,
-    name: SUBSCRIPTION_PLANS.FREE.name,
-    icon: Zap,
-    monthlyPrice: SUBSCRIPTION_PLANS.FREE.monthlyPrice,
-    annualPrice: SUBSCRIPTION_PLANS.FREE.annualPrice,
-    description: 'Full access for 7 days',
-    features: SUBSCRIPTION_PLANS.FREE.features,
-    cta: 'Start Free Trial',
-    href: '/onboarding',
-    popular: false,
-    disabled: false,
-  },
   {
     key: 'PRO' as const,
     name: SUBSCRIPTION_PLANS.PRO.name,
@@ -118,7 +105,7 @@ export function PricingSectionV2() {
   // Determine CTA text based on auth state
   const getCtaText = (plan: typeof plans[0]) => {
     if (plan.disabled) return plan.cta;
-    if (!isSignedIn) return 'Get Started';
+    if (!isSignedIn) return 'Start Free Trial';
     if (!isOnboarded) return 'Complete Setup';
     return plan.cta; // "Upgrade to Pro" or "Upgrade to Max"
   };
@@ -207,7 +194,7 @@ export function PricingSectionV2() {
             Simple, Transparent Pricing
           </h2>
           <p className="landing-body max-w-2xl mx-auto mb-8">
-            Start with a free trial, upgrade when you&apos;re ready. No hidden fees.
+            Start with a 7-day free trial on any plan. Cancel anytime.
           </p>
         </motion.div>
 
@@ -237,6 +224,9 @@ export function PricingSectionV2() {
               }`}
             />
           </button>
+          <p className="text-xs text-[var(--landing-text-muted)] mt-2">
+            Billing starts after your 7-day free trial
+          </p>
         </motion.div>
 
         {/* Pricing Cards Grid */}
@@ -245,7 +235,7 @@ export function PricingSectionV2() {
           initial="initial"
           whileInView="animate"
           viewport={viewportOnce}
-          className="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-5xl mx-auto"
+          className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-4xl mx-auto"
         >
           {plans.map((plan) => (
             <PricingCard

--- a/lib/stripe/plans.ts
+++ b/lib/stripe/plans.ts
@@ -10,21 +10,19 @@
 // =============================================================================
 export const SUBSCRIPTION_PLANS = {
   FREE: {
-    name: 'Trial',
+    name: 'Free',
     monthlyPriceId: null,
     annualPriceId: null,
     monthlyPrice: 0,
     annualPrice: 0,
     tickerLimit: -1, // unlimited (same as MAX)
-    filingTypes: ['ALL'] as const, // Trial users get all filing types to showcase full product
-    emailFrequency: 'realtime' as const,
+    filingTypes: ['ALL'] as const,
+    emailFrequency: 'realtime' as const, // Decorative: email delivery gated by pipeline at runtime
     features: [
       '**Unlimited** companies',
-      'Real-time email alerts',
+      'Dashboard access',
       'All SEC filing types',
-      '7-day trial period',
-      '**First** priority processing queue',
-      'Dedicated support',
+      'Background processing (2-hour intervals)',
     ],
   },
   PRO: {


### PR DESCRIPTION
## Summary

The landing page was still displaying a standalone "Trial" card in the pricing section despite the CC-required trial checkout model (PR #375). The new pricing model gives every user a 7-day free trial when they sign up for Pro or Max with a credit card.

**Changes:**
- Remove FREE tier from landing page pricing plans array (3-col → 2-col grid)
- Update CTA from "Get Started" to "Start Free Trial" for unauthenticated users
- Add trust copy: "7-day free trial included" and "Cancel anytime. No charge until day 8."
- Hide trial messaging for existing subscribers (`isCurrentPlan` guard)
- Remove dead `monthlyPrice === 0` branch from pricing card
- Rename plan `name: 'Trial'` → `name: 'Free'` in `plans.ts` for post-trial display
- Update billing page and dashboard to show "Free" instead of "Trial"
- Footer "Everything in X" now only shows on MAX tier (matches subscribe page)

## Pre-Landing Review

Review passed clean (0 issues). All 4 findings from first review pass addressed:
1. Scope drift resolved (Form 4 changes confirmed on main, not in this branch)
2. `emailFrequency` kept as `'realtime'` to avoid breaking notification delivery
3. Trial messaging hidden for existing subscribers
4. Dead code branch removed

## QA

Browser-tested on localhost:3000. Health score: 100/100.
- 2-tier layout renders correctly (desktop + mobile)
- Billing toggle works (monthly ↔ annual with Save 17% badges)
- CTAs redirect to `/sign-up?plan=pro` and `/sign-up?plan=max`
- Console: 0 errors

## Test plan
- [x] Lint passes (0 errors)
- [x] 51 pricing-related tests pass
- [x] 2 pre-existing failures (Stripe price ID env var, not related)
- [x] Browser QA verified on desktop and mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)