### PR TITLE
fix: onboarding conversion flow — copy, tutorial, campaign handoff, Stripe

### DIFF
--- a/__tests__/components/gmail-inbox-hero.test.tsx
+++ b/__tests__/components/gmail-inbox-hero.test.tsx
@@ -48,8 +48,8 @@ describe('GmailInboxHero', () => {
 
   it('shows metrics section', () => {
     render(<GmailInboxHero />);
-    expect(screen.getByText('2,500+')).toBeInTheDocument();
-    expect(screen.getByText('investors')).toBeInTheDocument();
+    expect(screen.getByText('10 min')).toBeInTheDocument();
+    expect(screen.getByText('filing-to-inbox')).toBeInTheDocument();
   });
 
   it('displays AI badge', () => {

--- a/__tests__/components/landing/cta-section-v2.test.tsx
+++ b/__tests__/components/landing/cta-section-v2.test.tsx
@@ -27,7 +27,7 @@ describe('CTASectionV2', () => {
 
   it('should display trust signals', () => {
     render(<CTASectionV2 />);
-    expect(screen.getByText(/No credit card/i)).toBeInTheDocument();
+    expect(screen.getByText(/7-day free trial/i)).toBeInTheDocument();
     expect(screen.getByText(/unlimited tickers/i)).toBeInTheDocument();
   });
 

--- a/__tests__/components/landing/hero-section-v2.test.tsx
+++ b/__tests__/components/landing/hero-section-v2.test.tsx
@@ -46,10 +46,10 @@ describe('HeroSectionV2', () => {
   // Test 5: Trust metrics are displayed
   it('should display trust metrics with specific values', () => {
     render(<HeroSectionV2 />);
-    expect(screen.getByText(/2,500\+/i)).toBeInTheDocument();
-    expect(screen.getByText(/investors/i)).toBeInTheDocument();
+    expect(screen.getByText(/10 min/i)).toBeInTheDocument();
+    expect(screen.getByText(/filing-to-inbox/i)).toBeInTheDocument();
     expect(screen.getByText(/99\.9%/i)).toBeInTheDocument();
-    expect(screen.getByText(/<5 min/i)).toBeInTheDocument();
+    expect(screen.getByText(/5 types/i)).toBeInTheDocument();
   });
 
   // Test 6: Filing preview card is rendered
@@ -60,10 +60,10 @@ describe('HeroSectionV2', () => {
     expect(screen.getByText(/10-K/i)).toBeInTheDocument();
   });
 
-  // Test 7: No credit card message is visible
-  it('should display trust signal about no credit card', () => {
+  // Test 7: Free trial message is visible
+  it('should display trust signal about free trial', () => {
     render(<HeroSectionV2 />);
-    expect(screen.getByText(/No credit card required/i)).toBeInTheDocument();
+    expect(screen.getByText(/7-day free trial/i)).toBeInTheDocument();
   });
 
   // Test 8: Uses light background (not dark)

--- a/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -2,6 +2,7 @@
 
 import { SignUp } from "@clerk/nextjs";
 import { useState, useEffect, useRef, useCallback } from "react";
+import { useSearchParams } from "next/navigation";
 
 function SkeletonBar({ className }: { className?: string }) {
   return (
@@ -57,6 +58,19 @@ function SignUpSkeleton() {
 export default function SignUpPage() {
   const [clerkLoaded, setClerkLoaded] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const searchParams = useSearchParams();
+
+  // Capture plan intent from campaign emails (e.g., ?plan=pro&ref=campaign)
+  useEffect(() => {
+    const plan = searchParams.get('plan');
+    const ref = searchParams.get('ref');
+    if (plan) {
+      document.cookie = `signup_plan=${plan};path=/;max-age=3600;SameSite=Lax`;
+    }
+    if (ref) {
+      document.cookie = `signup_ref=${ref};path=/;max-age=3600;SameSite=Lax`;
+    }
+  }, [searchParams]);
 
   const checkClerkContent = useCallback(() => {
     const el = containerRef.current;

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -39,47 +39,6 @@ export async function POST(request: NextRequest) {
       userAgent,
     });
 
-    // Handle FREE plan — check for existing accounts first, then create via magic link
-    if (planType === 'FREE') {
-      // Check if email is already registered in Clerk
-      const existingClerkUsers = await clerkClient.users.getUserList({
-        emailAddress: [email],
-        limit: 1,
-      });
-
-      if (existingClerkUsers.data.length > 0) {
-        return NextResponse.json(
-          { error: 'An account with this email already exists. Please sign in.' },
-          { status: 409 }
-        );
-      }
-
-      // Check if email exists in our database (e.g., from a previous webhook)
-      const existingDbUser = await getPrismaClient().user.findFirst({
-        where: { email },
-        select: { id: true },
-      }).catch(() => null);
-
-      if (existingDbUser) {
-        return NextResponse.json(
-          { error: 'An account with this email already exists. Please sign in.' },
-          { status: 409 }
-        );
-      }
-
-      // Create user with email verification required
-      const clerkUser = await clerkClient.users.createUser({
-        emailAddresses: [{ emailAddress: email }],
-        skipPasswordChecks: true,
-      });
-
-      return NextResponse.json({
-        planType: 'FREE',
-        redirectUrl: '/onboarding',
-        userId: clerkUser.id
-      });
-    }
-
     if (!stripe) {
       return NextResponse.json({ error: 'Stripe not configured' }, { status: 503 });
     }

--- a/app/subscribe/page.tsx
+++ b/app/subscribe/page.tsx
@@ -46,6 +46,9 @@ function SubscribePageContent() {
   const [downgradingTo, setDowngradingTo] = useState<PlanType | null>(null);
   const [showDowngradeConfirm, setShowDowngradeConfirm] = useState<PlanType | null>(null);
 
+  // Read pre-selected plan from query param (e.g., /subscribe?plan=pro from campaign flow)
+  const preSelectedPlan = (searchParams.get('plan')?.toUpperCase() as PlanType) || null;
+
   // Handle checkout cancellation - show toast
   useEffect(() => {
     if (searchParams.get('canceled') === 'true') {
@@ -56,6 +59,20 @@ function SubscribePageContent() {
       router.replace('/subscribe');
     }
   }, [searchParams, router]);
+
+  // Auto-trigger checkout when arriving with a pre-selected plan (campaign flow)
+  const [autoCheckoutTriggered, setAutoCheckoutTriggered] = useState(false);
+  useEffect(() => {
+    if (!loading && !autoCheckoutTriggered && preSelectedPlan && PLAN_ORDER.includes(preSelectedPlan)) {
+      const effectivePlan = getEffectivePlan();
+      // Only auto-trigger if user is on FREE and the pre-selected plan is an upgrade
+      if (effectivePlan === 'FREE' && PLAN_RANK[preSelectedPlan] > 0) {
+        setAutoCheckoutTriggered(true);
+        handleCheckout(preSelectedPlan);
+      }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading, preSelectedPlan, autoCheckoutTriggered]);
 
   // Fetch user's current subscription
   useEffect(() => {
@@ -361,7 +378,7 @@ function SubscribePageContent() {
                 transition={{ duration: 0.3, delay: index * 0.1 }}
                 whileHover={{ y: -4, boxShadow: '0 20px 40px -10px rgba(0, 0, 0, 0.15)' }}
                 className={`landing-card relative flex flex-col ${
-                  planKey === 'PRO' ? 'ring-2 ring-[var(--landing-primary)] shadow-lg' : ''
+                  planKey === 'PRO' || planKey === preSelectedPlan ? 'ring-2 ring-[var(--landing-primary)] shadow-lg' : ''
                 }`}
               >
                 {/* Popular Badge */}

--- a/components/dashboard/dashboard-client.tsx
+++ b/components/dashboard/dashboard-client.tsx
@@ -375,7 +375,7 @@ export function DashboardClient({ showWelcome: _showWelcome = false, shouldMerge
       </div>
 
       {/* Tabs: Activity / Tickers */}
-      <Tabs defaultValue="activity" className="w-full">
+      <Tabs defaultValue={showTutorial ? "tickers" : "activity"} className="w-full">
         <TabsList className="mb-4 bg-muted border border-border rounded-lg p-1">
           <TabsTrigger value="activity" className="data-[state=active]:bg-background data-[state=active]:shadow-sm data-[state=inactive]:text-muted-foreground px-4 py-1.5 text-sm font-medium rounded-md">Activity</TabsTrigger>
           <TabsTrigger value="tickers" className="data-[state=active]:bg-background data-[state=active]:shadow-sm data-[state=inactive]:text-muted-foreground px-4 py-1.5 text-sm font-medium rounded-md">Tickers</TabsTrigger>

--- a/components/landing/sections-v2/cta-section-v2.tsx
+++ b/components/landing/sections-v2/cta-section-v2.tsx
@@ -12,7 +12,7 @@ import { viewportOnce } from '@/lib/animations/landing-animations';
  * Reduces friction and builds confidence
  */
 const trustPoints = [
-  'No credit card required',
+  '7-day free trial',
   'Start with unlimited tickers',
   'Cancel anytime',
 ];

--- a/components/landing/sections-v2/gmail-inbox-hero.tsx
+++ b/components/landing/sections-v2/gmail-inbox-hero.tsx
@@ -415,9 +415,9 @@ const curatedSummaries: EmailSummary[] = [
  * Trust metrics displayed in the hero section
  */
 const trustMetrics = [
-  { value: '2,500+', label: 'investors' },
+  { value: '10 min', label: 'filing-to-inbox' },
   { value: '99.9%', label: 'uptime' },
-  { value: '<5 min', label: 'delivery' },
+  { value: '5 types', label: 'of SEC filings' },
 ];
 
 /**
@@ -966,7 +966,7 @@ export const GmailInboxHero = memo<GmailInboxHeroProps>(({ className = '', heroR
   // Extract caption logic for clarity
   const getCaptionText = () => {
     if (isSignedIn && !isOnboarded) return 'Just one more step!';
-    if (!isSignedIn) return 'No credit card required. Cancel anytime.';
+    if (!isSignedIn) return '7-day free trial. Cancel anytime.';
     return ''; // Authenticated and onboarded users see no caption
   };
 

--- a/components/landing/sections-v2/hero-section-v2.tsx
+++ b/components/landing/sections-v2/hero-section-v2.tsx
@@ -11,15 +11,15 @@ import {
   meshGradientStyle,
 } from '@/lib/animations/landing-animations';
 import { HeroFilingCard } from './hero-filing-card';
+import { useAuth } from '@/contexts/auth-context';
 
 /**
  * Trust metrics displayed in the hero section
- * Quantified social proof to build credibility
  */
 const trustMetrics = [
-  { value: '2,500+', label: 'investors' },
+  { value: '10 min', label: 'filing-to-inbox' },
   { value: '99.9%', label: 'uptime' },
-  { value: '<5 min', label: 'delivery' },
+  { value: '5 types', label: 'of SEC filings' },
 ];
 
 /**
@@ -33,6 +33,12 @@ const trustMetrics = [
  * - Clear CTA hierarchy
  */
 export function HeroSectionV2() {
+  const { isSignedIn, isOnboarded } = useAuth();
+
+  // Unauthenticated: go to sign-up. Signed in but not onboarded: go to onboarding. Onboarded: go to dashboard.
+  const ctaHref = !isSignedIn ? '/sign-up' : !isOnboarded ? '/onboarding' : '/dashboard';
+  const ctaLabel = !isSignedIn ? 'Start Free Trial' : !isOnboarded ? 'Complete Setup' : 'Go to Dashboard';
+
   return (
     <section
       className="relative min-h-[100vh] flex items-center overflow-hidden"
@@ -126,9 +132,9 @@ export function HeroSectionV2() {
               variants={staggerItem}
               className="flex flex-col sm:flex-row items-center justify-center lg:justify-start gap-4 mb-6"
             >
-              <Link href="/onboarding">
+              <Link href={ctaHref}>
                 <Button className="landing-button-gradient">
-                  Start Free Trial
+                  {ctaLabel}
                   <ArrowRight className="w-5 h-5 ml-2" />
                 </Button>
               </Link>
@@ -144,7 +150,7 @@ export function HeroSectionV2() {
               variants={staggerItem}
               className="landing-caption"
             >
-              No credit card required. Cancel anytime.
+              7-day free trial. Cancel anytime.
             </motion.p>
           </motion.div>
 

--- a/components/onboarding/onboarding-transition.tsx
+++ b/components/onboarding/onboarding-transition.tsx
@@ -33,7 +33,18 @@ export function OnboardingTransition() {
       const elapsed = Date.now() - startTime;
       const remaining = Math.max(0, MIN_DISPLAY_MS - elapsed);
       const timer = setTimeout(() => {
-        window.location.href = '/dashboard';
+        // Check if user came from a campaign with a plan intent
+        const planCookie = document.cookie.split('; ').find(c => c.startsWith('signup_plan='));
+        if (planCookie) {
+          const plan = planCookie.split('=')[1];
+          // Clear the cookie
+          document.cookie = 'signup_plan=; path=/; max-age=0';
+          document.cookie = 'signup_ref=; path=/; max-age=0';
+          // Redirect to subscribe page with plan pre-selected
+          window.location.href = `/subscribe?plan=${plan}`;
+        } else {
+          window.location.href = '/dashboard';
+        }
       }, remaining + 800); // small extra pause on "ready!"
       return () => clearTimeout(timer);
     }

--- a/components/onboarding/tutorial-guide.tsx
+++ b/components/onboarding/tutorial-guide.tsx
@@ -200,6 +200,22 @@ export function TutorialGuide({
     }
   }, [currentStep]);
 
+  const skipTutorial = useCallback(async () => {
+    try {
+      await updateTutorialProgress(100, {
+        currentStep: totalSteps - 1,
+        currentSubstep: 0,
+        completed: true,
+      });
+      setIsActive(false);
+      onComplete();
+    } catch (error) {
+      console.error('Error skipping tutorial:', error);
+      setIsActive(false);
+      onComplete();
+    }
+  }, [totalSteps, onComplete]);
+
   const completeTutorial = useCallback(async () => {
     try {
       // Immediately show confetti and hide overlay + tooltip
@@ -225,20 +241,13 @@ export function TutorialGuide({
         console.error('Failed to deliver cached summaries:', err);
       });
 
-      // Send welcome email in the background
-      fetch('/api/onboarding?action=welcome-email', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ data: {} })
-      }).catch(err => {
-        console.error('Failed to send welcome email:', err);
-      });
+      // Welcome email already sent by completeOnboardingBatched — no duplicate needed
 
-      // Hide tutorial after confetti (5s)
+      // Hide tutorial after confetti (2s)
       setTimeout(() => {
         setIsActive(false);
         onComplete();
-      }, 5000);
+      }, 2000);
     } catch (error) {
       console.error('Error completing tutorial:', error);
       toast.error('Something went wrong. Please try again.');
@@ -360,7 +369,13 @@ export function TutorialGuide({
             <div className="p-1.5 rounded-full" style={{ background: 'linear-gradient(135deg, #0079F2, #8B5CF6)' }}>
               <span className="text-white">{step?.icon || <List className="h-5 w-5" />}</span>
             </div>
-            <h3 className="font-semibold text-sm">{step?.title || 'Tutorial'}</h3>
+            <h3 className="font-semibold text-sm flex-1">{step?.title || 'Tutorial'}</h3>
+            <button
+              onClick={skipTutorial}
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Skip
+            </button>
           </div>
 
           {/* Progress bar */}

--- a/lib/stripe/reconcile.ts
+++ b/lib/stripe/reconcile.ts
@@ -37,14 +37,14 @@ export async function reconcileStripeSubscription(
   const customers = await stripe.customers.list({ email, limit: 3 });
 
   for (const customer of customers.data) {
-    const activeSubs = await stripe.subscriptions.list({
-      customer: customer.id,
-      status: 'active',
-      limit: 1,
-    });
+    // Check both 'active' and 'trialing' — CC-required trials create 'trialing' status
+    const [activeSubs, trialingSubs] = await Promise.all([
+      stripe.subscriptions.list({ customer: customer.id, status: 'active', limit: 1 }),
+      stripe.subscriptions.list({ customer: customer.id, status: 'trialing', limit: 1 }),
+    ]);
 
-    if (activeSubs.data.length > 0) {
-      const sub = activeSubs.data[0];
+    const sub = activeSubs.data[0] || trialingSubs.data[0];
+    if (sub) {
       const priceId = sub.items.data[0]?.price.id;
       const derivedPlanType = getPlanTypeFromPriceId(priceId);
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -376,9 +376,32 @@ export default async function middleware(request: NextRequest) {
       const url = new URL(request.url);
       const pathname = url.pathname;
 
-      // Redirect authenticated users away from auth pages to dashboard
-      const { userId } = await auth();
+      // Redirect authenticated users away from auth pages
+      const { userId, sessionClaims } = await auth();
       if (userId && (pathname.startsWith('/sign-up') || pathname.startsWith('/sign-in'))) {
+        // Check if onboarding is completed via Clerk publicMetadata or cookie fallback
+        const metadata = (sessionClaims as Record<string, unknown>)?.metadata as Record<string, unknown> | undefined;
+        const onboardingCompleted =
+          metadata?.onboardingCompleted === true ||
+          request.cookies.get('onboarding_completed')?.value === 'true';
+
+        // Preserve plan/ref params from campaign emails as cookies
+        // (the sign-up page's useEffect won't run since we redirect server-side)
+        const plan = url.searchParams.get('plan');
+        const ref = url.searchParams.get('ref');
+
+        if (!onboardingCompleted) {
+          const response = NextResponse.redirect(new URL('/onboarding', request.url));
+          if (plan) response.cookies.set('signup_plan', plan, { path: '/', maxAge: 3600, sameSite: 'lax' });
+          if (ref) response.cookies.set('signup_ref', ref, { path: '/', maxAge: 3600, sameSite: 'lax' });
+          return response;
+        }
+
+        // Already onboarded — if they have a plan intent, send to subscribe
+        if (plan) {
+          const subscribeUrl = new URL(`/subscribe?plan=${plan}`, request.url);
+          return NextResponse.redirect(subscribeUrl);
+        }
         return NextResponse.redirect(new URL('/dashboard', request.url));
       }
 


### PR DESCRIPTION
## Summary

Pre-launch audit of the email campaign → sign-up → onboarding → trial → paid conversion funnel. Fixes 7 P0 blockers identified during /autoplan review.

**Trust & Copy**
- Remove "No credit card required" from all hero sections (contradicts CC-required Stripe trial)
- Replace fabricated "2,500+ investors" with honest metrics (filing-to-inbox time, uptime, filing types)
- Hero CTA is now auth-aware: shows "Start Free Trial" / "Complete Setup" / "Go to Dashboard"

**Campaign Conversion Flow**
- Sign-up page captures `?plan=pro&ref=campaign` params as cookies
- Middleware preserves plan intent for already-authenticated users redirecting from `/sign-up`
- Onboarding transition reads plan cookie and redirects to `/subscribe?plan=pro`
- Subscribe page auto-triggers checkout for pre-selected plan on FREE users

**Tutorial UX**
- Fix tutorial step 1 targeting element behind inactive Tickers tab (default to Tickers tab when tutorial active)
- Add Skip button for professionals who don't need hand-holding
- Reduce confetti delay from 5s to 2s
- Remove duplicate welcome email (already sent by completeOnboardingBatched)

**Stripe**
- `reconcileStripeSubscription` now checks both `active` and `trialing` subscription status
- Remove dead FREE plan branch from checkout route (Zod rejects FREE, `clerkClient` was never imported)

## Pre-Landing Review

No issues found. All changes are UI copy, cookie handling, and conditional redirects. No SQL, no LLM output, no shell commands, no new enum values.

## Adversarial Review

Claude subagent found 0 issues in branch changes. 17 pre-existing findings flagged in cron/webhook/auth code (not touched by this branch).

## Test plan
- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [ ] Unit tests have pre-existing ESM/CJS infrastructure failure (setup-integration.js uses require() in ESM context — not caused by this branch)
- [ ] QA: verify campaign email CTA → sign-up → onboarding → subscribe flow
- [ ] QA: verify tutorial spotlight targets Add Ticker button correctly
- [ ] QA: verify "No credit card required" removed from all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)