### PR TITLE
fix: subscription validation errors and Clerk deprecated props on landing page

### DIFF
--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -29,6 +29,11 @@ import {
 import { TrialService } from '@/lib/auth/trial-service';
 
 type BillingInterval = 'monthly' | 'annual';
+
+/** Infinity is not valid JSON — clamp to a safe sentinel that the client treats as "unlimited". */
+function safeDaysRemaining(days: number): number {
+  return Number.isFinite(days) ? days : 9999;
+}
 type NewPlanKey = 'FREE' | 'PRO' | 'MAX';
 
 const prisma = getPrismaClient();
@@ -206,6 +211,7 @@ async function handleGetSubscription() {
       return NextResponse.json({
         planType: 'FREE',
         isActive: true,
+        currentPeriodStart: new Date().toISOString(),
         currentPeriodEnd: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
         cancelAtPeriodEnd: false,
         stripeCustomerId: null,
@@ -218,7 +224,7 @@ async function handleGetSubscription() {
         _stripeDisabled: true,
         trialEndsAt: trialData.trialEndsAt?.toISOString() ?? null,
         isTrialing: trialData.isActive,
-        daysRemaining: trialData.daysRemaining,
+        daysRemaining: safeDaysRemaining(trialData.daysRemaining),
         isGrandfathered: trialData.isGrandfathered,
       });
     }
@@ -255,6 +261,7 @@ async function handleGetSubscription() {
       return NextResponse.json({
         planType: 'FREE',
         isActive: true,
+        currentPeriodStart: new Date().toISOString(),
         currentPeriodEnd: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
         cancelAtPeriodEnd: false,
         stripeCustomerId: null,
@@ -266,7 +273,7 @@ async function handleGetSubscription() {
         },
         trialEndsAt: trialData.trialEndsAt?.toISOString() ?? null,
         isTrialing: trialData.isActive,
-        daysRemaining: trialData.daysRemaining,
+        daysRemaining: safeDaysRemaining(trialData.daysRemaining),
         isGrandfathered: trialData.isGrandfathered,
       });
     }
@@ -300,7 +307,7 @@ async function handleGetSubscription() {
       },
       trialEndsAt: trialData.trialEndsAt?.toISOString() ?? null,
       isTrialing: trialData.isActive,
-      daysRemaining: trialData.daysRemaining,
+      daysRemaining: safeDaysRemaining(trialData.daysRemaining),
       isGrandfathered: trialData.isGrandfathered,
     });
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -58,8 +58,8 @@ export default function RootLayout({
   
   return (
     <ClerkProviderWrapper
-      afterSignUpUrl="/onboarding"
-      afterSignInUrl="/dashboard"
+      signUpFallbackRedirectUrl="/onboarding"
+      signInFallbackRedirectUrl="/dashboard"
       signUpUrl="/sign-up"
       signInUrl="/sign-in"
     >

--- a/components/auth/clerk-provider-wrapper.tsx
+++ b/components/auth/clerk-provider-wrapper.tsx
@@ -5,8 +5,8 @@ import { ReactNode } from 'react';
 
 interface ClerkProviderWrapperProps {
   children: ReactNode;
-  afterSignUpUrl?: string;
-  afterSignInUrl?: string;
+  signInFallbackRedirectUrl?: string;
+  signUpFallbackRedirectUrl?: string;
   signUpUrl?: string;
   signInUrl?: string;
 }
@@ -14,10 +14,10 @@ interface ClerkProviderWrapperProps {
 /**
  * Wrapper around ClerkProvider that handles missing publishable key during build time
  */
-export function ClerkProviderWrapper({ 
-  children, 
-  afterSignUpUrl,
-  afterSignInUrl,
+export function ClerkProviderWrapper({
+  children,
+  signInFallbackRedirectUrl,
+  signUpFallbackRedirectUrl,
   signUpUrl,
   signInUrl
 }: ClerkProviderWrapperProps) {
@@ -38,8 +38,8 @@ export function ClerkProviderWrapper({
   
   return (
     <ClerkProvider
-      afterSignUpUrl={afterSignUpUrl}
-      afterSignInUrl={afterSignInUrl}
+      signUpFallbackRedirectUrl={signUpFallbackRedirectUrl}
+      signInFallbackRedirectUrl={signInFallbackRedirectUrl}
       signUpUrl={signUpUrl}
       signInUrl={signInUrl}
     >

--- a/lib/validation/subscription-schema.ts
+++ b/lib/validation/subscription-schema.ts
@@ -35,7 +35,7 @@ export const SSEUpdateSchema = z.object({
     planType: z.enum(['FREE', 'PRO', 'MAX']),
     isActive: z.boolean(),
     isTrialing: z.boolean(),
-    daysRemaining: z.number().min(0),
+    daysRemaining: z.number(),
     trialEndsAt: z.string().nullable(),
     isGrandfathered: z.boolean(),
   }),

--- a/lib/validation/subscription-schema.ts
+++ b/lib/validation/subscription-schema.ts
@@ -8,7 +8,7 @@ export const SubscriptionDataSchema = z.object({
   planType: z.enum(['FREE', 'PRO', 'MAX']),
   isActive: z.boolean(),
   isTrialing: z.boolean(),
-  daysRemaining: z.number().min(0),
+  daysRemaining: z.number(),
   trialEndsAt: z.string().nullable(),
   isGrandfathered: z.boolean(),
   currentPeriodStart: z.string().nullable(),
@@ -17,9 +17,9 @@ export const SubscriptionDataSchema = z.object({
   stripeCustomerId: z.string().nullable(),
   stripeSubscriptionId: z.string().nullable(),
   limits: z.object({
-    monthlyFilings: z.number().min(0),
+    monthlyFilings: z.number(),
     usedFilings: z.number().min(0),
-    remainingFilings: z.number().min(0),
+    remainingFilings: z.number(),
   }),
 });
 


### PR DESCRIPTION
## Summary

Fixes the yellow error banner ("Unable to load subscription status") visible on the production landing page pricing section, plus Clerk deprecation warnings in console.

**Root causes:**
- `daysRemaining` serialized as `null` because `JSON.stringify(Infinity)` returns `null` — `TrialService` returns `Infinity` for paid/grandfathered users
- `currentPeriodStart` missing from FREE-tier fallback API responses, causing `undefined` at the client
- `limits.monthlyFilings` and `remainingFilings` returning `-1` (unlimited sentinel from `SUBSCRIPTION_PLANS.FREE.tickerLimit`), failing `z.number().min(0)` validation
- Clerk `afterSignUpUrl`/`afterSignInUrl` props deprecated in favor of `signUpFallbackRedirectUrl`/`signInFallbackRedirectUrl`

**Changes:**
- `app/api/user/route.ts` — `safeDaysRemaining()` helper clamps `Infinity` to `9999`, added `currentPeriodStart` to all FREE fallback responses
- `lib/validation/subscription-schema.ts` — relaxed Zod schema for `daysRemaining` (allow any number) and `limits` fields (allow `-1` for unlimited)
- `components/auth/clerk-provider-wrapper.tsx` — migrated to non-deprecated Clerk redirect props
- `app/layout.tsx` — updated prop names to match wrapper

## Evidence

Verified on production (`https://tldrsec.app`) via headless browser:
- Yellow banner visible: "Unable to load subscription status"
- Console shows 4 Zod validation errors matching the exact fields fixed
- Screenshot captured in `.gstack/qa-reports/screenshots/`

## Test plan
- [x] 42 tests pass across 4 related test suites (subscribe, subscription-context, pricing-section-v2, pricing-card, landing-page-auth)
- [x] TypeScript type-check passes for all changed files
- [ ] Deploy and verify error banner is gone on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)