### PR TITLE
chore: add SOUL.md, USER.md, AGENTS.md identity files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md
+
+> Non-Claude agent operating protocol (OpenClaw, Hermes, Codex, etc.).
+> **For Claude Code, all routing lives in [CLAUDE.md](./CLAUDE.md) — single source of truth.**
+
+## Read Order (any agent)
+
+1. **CLAUDE.md** — project rules, skill routing, recurring tasks, common mistakes.
+2. **SOUL.md** — Wilfred's worldview, engineering philosophy, decision framework.
+3. **USER.md** — practical operating profile, communication style, project gotchas.
+4. **Obsidian vault** at `~/Software/Obsidian/tldrsec-ai/wiki/` — domain knowledge.
+   Read `wiki/overview.md`, `wiki/product/`, `wiki/sec/` before exploring raw source.
+
+## Trust Boundary (any agent)
+
+- **Reversible local actions** (edit files, run tests, read-only DB queries): proceed.
+- **Irreversible / shared-state actions** (push, force-push, drop tables, send messages, deploy, modify shared infra): confirm first.
+- Never skip git hooks (`--no-verify`), bypass signing, or run destructive ops without explicit ask.
+- Never put API keys in shell config; `.env.local` only.
+
+## Skill / Subagent Routing
+
+- **Claude Code:** see CLAUDE.md `## Skill routing` and the project's `.claude/agents/` directory. Do not duplicate that table here — it drifts.
+- **Other agents:** consult your own resolver/skill registry. The triggers in CLAUDE.md describe intents (e.g., "ship → /ship") that map cleanly to most agent frameworks; mirror them in your own protocol if useful.
+
+## Anti-Drift Guards (any agent)
+
+1. Don't write to scattered scratch markdown files. Use the Obsidian vault, or `tasks/<TASK>.md` for plans.
+2. Hidden state in local memory not reflected in code → if it matters, commit it.
+3. Don't mark "done" without proof. Run the test, check the diff.
+4. Don't refactor adjacent code that wasn't asked for.
+5. No "helpful" backwards-compat shims for unused code paths.
+
+## Recursive Improvement (any agent)
+
+- After a dev cycle ships → distill what was learned into the Obsidian vault (`wiki/analysis/` or relevant category).
+- Corrections from Wilfred → append to `tasks/lessons.md`. Read at next session start.
+- New product question answered → write the answer as a vault page so it compounds.

--- a/SOUL.md
+++ b/SOUL.md
@@ -1,0 +1,75 @@
+# SOUL.md — Wilfred's Identity & Worldview
+
+> The agent's reference for *how Wilfred thinks*. Specificity beats vagueness — someone reading this should be able to predict Wilfred's take on a new topic. Real opinions with reasoning. Real contradictions. No sanitized hedging.
+
+## Who I Am
+
+<!-- TODO: 2-3 sentences. Who you are, what you do, what you're building. Not a resume — a worldview snippet. -->
+- Building tldrsec-ai: AI-summarized SEC filings for retail investors and operators.
+- Background: <!-- TODO: fill in -->
+- Operating context: solo / small team building fast with AI agents (Claude Code, Conductor parallel workspaces).
+
+## Engineering Philosophy
+
+These are load-bearing — every code decision routes through them.
+
+**Elon's 5 steps (in order, never skip):**
+1. **Make the requirements less dumb.** Requirements from smart people are the most dangerous because they go unquestioned. Tag the human, not the department.
+2. **Delete the part or process step.** Presumed guilty until proven innocent. If you're not occasionally adding things back, you haven't deleted enough.
+3. **Simplify or optimize.** Only after 1–2. The most common engineering mistake is optimizing something that shouldn't exist.
+4. **Accelerate cycle time.** Only after 1–3.
+5. **Automate.** Only after 1–4. Don't automate a broken process.
+
+**Karpathy-style discipline:**
+- Think before coding. State assumptions. Surface tradeoffs. Ask if uncertain.
+- Simplicity first. If 200 lines could be 50, rewrite. No speculative abstractions.
+- Surgical changes. Touch only what's required. Don't "improve" adjacent code.
+- No laziness. Find root causes. Senior-developer standard.
+- Goal-driven execution. Define the success criterion *before* writing code.
+
+## Strong Opinions
+
+<!-- TODO: list 5–10 takes you actually hold, with the reasoning. The point is for the agent to predict your stance on new topics. Be specific — "no mocks for X because Y" beats "I prefer integration tests". Real opinions, real reasoning, not platitudes. -->
+
+The two below come from CLAUDE.md and are confirmed. Add yours below them.
+
+- **Plan mode by default.** Any non-trivial task = plan first, write to `tasks/<TASK>.md`, review before implementing. Why: cheap to fix on paper, expensive to fix in code.
+- **Subagents are free compute.** Use them liberally to keep main context clean.
+- <!-- TODO: your real opinion #3 -->
+- <!-- TODO: your real opinion #4 -->
+- <!-- TODO: your real opinion #5 -->
+
+## What I Reject
+
+<!-- TODO: things you actively push back on. Anti-patterns in code, business, design. -->
+- Premature abstraction. Three similar lines beat a wrong abstraction.
+- Backwards-compat hacks for code with no external consumers.
+- "Just to be safe" error handling for impossible scenarios.
+- Tests that mock the thing they're supposed to verify.
+- Renames-as-cleanup mixed into feature PRs.
+
+## How I Decide
+
+- **Reversible decisions** (local code changes, refactors): act, observe, adjust.
+- **Irreversible decisions** (DB schema, public API, deployment, branding): plan mode, second opinion, slow down.
+- **Tiebreakers**: simpler wins. Existing pattern wins. Explicit beats clever.
+
+## Influences & References
+
+<!-- TODO: who/what shapes your thinking. Specific names, not "smart people." -->
+- Elon Musk (engineering algorithm, first-principles requirements pruning)
+- Andrej Karpathy (LLM-native development, "vibe coding" with discipline)
+- Paul Graham / YC essays (founder mindset, default-to-shipping)
+- <!-- TODO: add yours -->
+
+## Real Contradictions
+
+<!-- TODO: this is where SOUL.md gets useful. Honest tensions you actually hold. -->
+- I prize simplicity but I run many parallel Conductor workspaces — operational complexity.
+- I want speed but I run plan mode by default — friction up front to remove friction later.
+- <!-- TODO: add your real ones -->
+
+## Things I Am Wrong About (sometimes)
+
+<!-- TODO: known blind spots. Lets the agent push back when relevant. -->
+- <!-- TODO: e.g., "I underestimate frontend polish" or "I over-trust LLM output for edge cases" -->

--- a/USER.md
+++ b/USER.md
@@ -1,0 +1,79 @@
+# USER.md — Operating Profile
+
+> Practical context for the agent. *How to work with Wilfred*, not who he is. Read this before responding; SOUL.md tells you *why*, this tells you *how*.
+
+## Identity
+
+- **Name:** Wilfred Chen
+- **Email:** wilfredchen1@gmail.com (primary), wilfred.chen.python@gmail.com (project-tagged)
+- **Project:** tldrsec-ai — SEC filing summarization product
+- **Working directory:** `/Users/wilf/conductor/workspaces/tldrsec-ai/casablanca` (one of several parallel Conductor workspaces)
+
+## Tools & Environment
+
+- **Editor/agent:** Claude Code, with parallel Conductor workspaces. Multiple workspaces may share `localhost:3000` — verify which workspace owns the port before diagnosing dev-only bugs.
+- **LLM provider for product features:** xAI Grok (NOT Anthropic). All AI features in this codebase route through Grok.
+- **Knowledge base:** Obsidian vault at `~/Software/Obsidian/tldrsec-ai/` — single source of truth for domain knowledge. Read `wiki/overview.md`, `wiki/product/`, `wiki/sec/` before exploring raw source files.
+- **Env files:** `.env.local` per workspace; do NOT put API keys in shell config.
+
+## Communication Style
+
+- Terse responses. Short and concise. No trailing summary if the diff already shows it.
+- Don't explain what changed line-by-line — give the high-level "why".
+- Use `path:line` for code references.
+- Surface tradeoffs and assumptions explicitly. Ask before guessing.
+- One sentence updates between tool calls when working; not a running monologue.
+
+## Workflow Defaults
+
+- **Plan mode** for any non-trivial task (3+ steps or architectural). Write plans to `tasks/<TASK_NAME>.md`. Review with Wilfred before implementing. List unresolved questions at the end.
+- **Self-improvement loop:** after corrections, append the lesson to `tasks/lessons.md`. Read at session start.
+- **Verification before "done":** never mark complete without proof. Run tests, check logs, demonstrate.
+- **Git hygiene:** new commits, never amend. Don't push without explicit ask. Branch naming: `wilfred-py/<concise-name>`.
+- **Pre-commit:** run `git status` and `npm test` before committing.
+
+## Recurring Manual Tasks
+
+- **Landing-page Gmail fixtures** (`lib/landing/gmail-mock-summaries.ts`) — refresh weekly.
+  - Run `npx tsx scripts/refresh-landing-fixtures.ts` against prod (uses `.env.local`).
+  - Pick 15 from candidates, hand-curate (editorial voice, news-verified, ≥8 brand-recognition tickers).
+  - "Updated weekly" footer copy in the hero is a public promise — don't let this slip.
+
+## Project-Specific Gotchas
+
+- Use `getPrismaClient()`, NOT direct `prisma` import (direct import fails in API routes).
+- `CRON_SECRET` must be exactly 80 chars.
+- Look up users by `authProviderId` not just `id` — Clerk userId lives in `authProviderId`.
+- Sync `User.subscriptionTier` via `syncUserSubscriptionTier()` in Stripe webhooks.
+- Jest mock hoisting: don't reference `const` in `jest.mock()` factories.
+- Don't use `{ not: null }` on required Prisma fields.
+- Define CSS animations explicitly via `@layer utilities` in `app/globals.css`.
+
+## What I'm Optimizing For
+
+<!-- TODO: confirm/edit -->
+- Shipping useful features for retail investors fast.
+- Compounding knowledge in the Obsidian vault, not scratch markdown files.
+- Keeping email as the primary product surface.
+
+## What I'm NOT Optimizing For
+
+- Pixel-perfect dashboard polish (until it's the bottleneck).
+- Backwards compatibility with hypothetical future consumers.
+- Test coverage for impossible edge cases.
+
+## Boundaries / Don'ts
+
+- Don't write speculative abstractions or "future-proofing" code.
+- Don't add comments explaining WHAT — only non-obvious WHY.
+- Don't create planning/decision/analysis docs unless asked.
+- Don't auto-commit. Don't push to remote without explicit ask.
+- Don't modify shared infrastructure or `git config` without confirming.
+- Don't summarize what you just did at the end of every response.
+
+## When to Interrupt Me
+
+- You've found something genuinely surprising in the code.
+- The plan is about to do something irreversible.
+- Two interpretations of the request exist — ask, don't pick.
+- You hit a blocker you can't reason past.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tldrsec-ai",
-  "version": "0.1.3",
+  "version": "0.0.24.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tldrsec-ai",
-      "version": "0.1.3",
+      "version": "0.0.24.12",
       "dependencies": {
         "@anthropic-ai/claude-code": "2.0.37",
         "@anthropic-ai/sdk": "^0.63.1",


### PR DESCRIPTION
## Summary

- Adds Garry Tan-style agent identity scaffold: **SOUL.md** (worldview), **USER.md** (operating profile), **AGENTS.md** (non-Claude agent pointer).
- Establishes single read-order for any agent entering the repo: CLAUDE.md → SOUL.md → USER.md → Obsidian vault.
- AGENTS.md is intentionally thin and defers all skill routing to CLAUDE.md to avoid duplication/drift.
- Syncs `package-lock.json` version (`0.1.3` → `0.0.24.12`) to match `package.json`.

## Why

Non-Claude agents (OpenClaw, Codex, Hermes) and future Claude sessions need a stable identity layer separate from Claude-specific routing. SOUL/USER split mirrors gbrain/gstack: SOUL = *why*, USER = *how*.

## Follow-ups (for Wilfred)

SOUL.md and USER.md ship with TODO placeholders. They become predictively useful only when filled in:
- SOUL.md: Background, Strong Opinions, Real Contradictions, Blind Spots
- USER.md: "What I'm Optimizing For" confirmation

## Test plan

- [x] All three files render as valid markdown
- [x] AGENTS.md skill-routing section points to CLAUDE.md (no duplicated table)
- [x] No source code touched — docs-only change
- [ ] Wilfred fills in SOUL.md TODOs in a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)