### PR TITLE
feat(ai): X sentiment image+video understanding (v0.0.25.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.25.2] - 2026-04-29
+
+### Changed
+- **X sentiment pipeline now ingests images and videos** — the `x_search` tool is invoked with `enable_image_understanding: true` and `enable_video_understanding: true` so chart screenshots, product demos, and earnings-call clips factor into the sentiment synthesis. Prompt updated to instruct the model to incorporate visual context but cite the post URL, not the media asset. End-to-end smoke test on TSLA over a 7-day window: $0.0614 / call, 38s latency, 12 citations, bullish/shifting_bullish/high — visual posts surfaced cleanly without polluting citations.
+- `lib/ai/xai-direct-client.ts` — `XaiTool` union expanded to expose `enable_image_understanding` (x_search + web_search) and `enable_video_understanding` (x_search) flags so callers can opt in type-safely.
+
+### Fixed
+- **Citation URL pollution from image-CDN hosts** — with image understanding enabled, `extractCitationUrls` was picking up `pbs.twimg.com/media/*` and `video.twimg.com/*` asset URLs from the response payload and persisting them onto `summaryJSON.citationUrls`, which would have broken any downstream tweet-embed UI assuming `x.com/{handle}/status/{id}` shape. Validator's `isValidUrl` now allowlists trusted citation hosts (`x.com`, `www.x.com`, `twitter.com`, `www.twitter.com`, `mobile.twitter.com`) and drops everything else into the `urlsStripped` counter for observability.
+
 ## [0.0.25.1] - 2026-04-29
 
 ### Fixed

--- a/lib/ai/__tests__/x-sentiment-provider.test.ts
+++ b/lib/ai/__tests__/x-sentiment-provider.test.ts
@@ -200,11 +200,17 @@ describe('getXSentiment', () => {
       expect(promptArg).toContain('Apple Inc');
     });
 
-    it('uses x_search tool only', async () => {
+    it('uses x_search tool with image + video understanding enabled', async () => {
       mockCallXai.mockResolvedValue(buildXaiResponse());
       await getXSentiment({ ticker: 'AAPL', formType: '8-K', companyName: 'Apple Inc' });
       const tools = mockCallXai.mock.calls[0][0].tools;
-      expect(tools).toEqual([{ type: 'x_search' }]);
+      expect(tools).toEqual([
+        {
+          type: 'x_search',
+          enable_image_understanding: true,
+          enable_video_understanding: true,
+        },
+      ]);
     });
 
     it('clamps windowHours to [1, 168]', async () => {

--- a/lib/ai/parsers/__tests__/x-sentiment-validator.test.ts
+++ b/lib/ai/parsers/__tests__/x-sentiment-validator.test.ts
@@ -183,6 +183,24 @@ describe('validateXSentiment', () => {
       });
       expect(sentiment!.citationUrls).toEqual(['https://x.com/ok/1']);
     });
+
+    it('drops media-CDN and off-host URLs from citations', () => {
+      const { sentiment, stats } = validateXSentiment({
+        ...baseValid,
+        citationUrls: [
+          'https://pbs.twimg.com/media/HGbqxSuWgAAl9ma.jpg',
+          'https://video.twimg.com/ext_tw_video/abc.mp4',
+          'https://attacker.example/pump',
+          'https://x.com/Bloomberg/status/123',
+          'https://twitter.com/CNBC/status/456',
+        ],
+      });
+      expect(sentiment!.citationUrls).toEqual([
+        'https://x.com/Bloomberg/status/123',
+        'https://twitter.com/CNBC/status/456',
+      ]);
+      expect(stats.urlsStripped).toBe(3);
+    });
   });
 
   describe('windowHours bounds', () => {

--- a/lib/ai/parsers/x-sentiment-validator.ts
+++ b/lib/ai/parsers/x-sentiment-validator.ts
@@ -106,11 +106,25 @@ function containsPriceTarget(text: string): boolean {
   return PRICE_TARGET_PATTERNS.some((p) => p.test(text));
 }
 
+// Citations must point at the X post itself, not at media CDN assets. With
+// `enable_image_understanding` on, xai-direct-client.extractCitationUrls picks
+// up `pbs.twimg.com/media/*` image URLs from the response payload — letting
+// those through pollutes summaryJSON.citationUrls and breaks any future
+// tweet-embed UI that assumes x.com/{handle}/status/{id} shape.
+const TRUSTED_CITATION_HOSTS: ReadonlySet<string> = new Set([
+  'x.com',
+  'www.x.com',
+  'twitter.com',
+  'www.twitter.com',
+  'mobile.twitter.com',
+]);
+
 function isValidUrl(value: unknown): value is string {
   if (typeof value !== 'string') return false;
   try {
     const u = new URL(value);
-    return u.protocol === 'http:' || u.protocol === 'https:';
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return false;
+    return TRUSTED_CITATION_HOSTS.has(u.hostname.toLowerCase());
   } catch {
     return false;
   }

--- a/lib/ai/x-sentiment-provider.ts
+++ b/lib/ai/x-sentiment-provider.ts
@@ -117,6 +117,8 @@ Use the x_search tool to gather posts from the last ${windowHours} hours that me
   - Have meaningful engagement (likes, reposts, replies)
   - Come from accounts with non-trivial follower counts or verified status
 
+When posts contain images or videos (chart screenshots, product demos, earnings-call clips), incorporate what they depict into the synthesis — but cite the post URL, not the media itself.
+
 Then synthesize a sentiment assessment. Distinguish between:
   - Verifiable facts (numeric, dated, sourced) → factClaims
   - Opinion / interpretation / speculation       → opinionClaims
@@ -229,7 +231,17 @@ export async function getXSentiment(input: XSentimentInput): Promise<XSentimentR
   try {
     response = await callXaiResponses({
       input: prompt,
-      tools: [{ type: 'x_search' }],
+      // Image + video understanding lets x_search incorporate visual posts
+      // (chart screenshots, product demos, earnings-call clips) into the
+      // sentiment synthesis. Increases token usage — actual cost is reconciled
+      // against the budget envelope via response.usage.costUsd.
+      tools: [
+        {
+          type: 'x_search',
+          enable_image_understanding: true,
+          enable_video_understanding: true,
+        },
+      ],
       timeoutMs,
     });
   } catch (err) {

--- a/lib/ai/xai-direct-client.ts
+++ b/lib/ai/xai-direct-client.ts
@@ -23,7 +23,24 @@ const DEFAULT_MODEL = 'grok-4.20-reasoning';
 
 const TICK_TO_USD = 1e-10;
 
-export type XaiTool = { type: 'x_search' } | { type: 'web_search' };
+export type XaiXSearchTool = {
+  type: 'x_search';
+  allowed_x_handles?: string[];
+  excluded_x_handles?: string[];
+  from_date?: string;
+  to_date?: string;
+  enable_image_understanding?: boolean;
+  enable_video_understanding?: boolean;
+};
+
+export type XaiWebSearchTool = {
+  type: 'web_search';
+  allowed_domains?: string[];
+  excluded_domains?: string[];
+  enable_image_understanding?: boolean;
+};
+
+export type XaiTool = XaiXSearchTool | XaiWebSearchTool;
 
 export interface XaiResponseRequest {
   model?: string;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tldrsec-ai",
-  "version": "0.0.24.12",
+  "version": "0.0.25.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- Enable `enable_image_understanding` + `enable_video_understanding` on the X-sentiment `x_search` tool so chart screenshots, product demos, and earnings-call clips feed the synthesis. Prompt nudge added so the model uses visual context but cites the post URL, not the media asset.
- Tighten `x-sentiment-validator.isValidUrl` to an allowlist of trusted hosts (`x.com` / `twitter.com`) so `pbs.twimg.com` / `video.twimg.com` asset URLs surfaced by image understanding don't pollute `summaryJSON.citationUrls` (caught during `/review`).
- Expand `XaiTool` union in `xai-direct-client` to expose the flags type-safely.

## E2E smoke test
TSLA / last 7 days / most recent 10-Q (accession `0001628280-26-026673`):
- Cost: **$0.0614** (vs ~$0.05 prior approximation — slight drift, recommend bumping `APPROX_COST_USD` after ~10 prod samples)
- Latency: 38s
- Citations: 12 (all `x.com/...` after the validator fix)
- Verdict: bullish / shifting_bullish / high

## Test plan
- [x] `npx jest lib/ai/__tests__/x-sentiment-provider.test.ts lib/ai/parsers/__tests__/x-sentiment-validator.test.ts` — 50 tests pass
- [x] Provider tool-shape test asserts both flags are `true`
- [x] Validator test asserts `pbs.twimg.com`, `video.twimg.com`, and off-host URLs are dropped while `x.com` / `twitter.com` URLs pass through
- [x] One-shot e2e against real xAI Responses API (TSLA, 7d, 10-Q): cost / latency / citations all green
- [ ] Post-deploy: monitor `ai.x_sentiment_imperative_stripped` and `ai.x_sentiment_confidence_demoted` rates to detect any image-borne prompt-injection signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)