### PR TITLE
feat(launch): soft Lifetime tease in VRT founder note P.S.

### DIFF
--- a/lib/email/__fixtures__/launch-2026-05-vrt.ts
+++ b/lib/email/__fixtures__/launch-2026-05-vrt.ts
@@ -168,7 +168,9 @@ What I wanted was an equity analyst in my pocket. Someone who reads each filing 
 
 That is what tldrSEC is. An equity analyst who never gets tired, never misses anything, with a 360 degree birds-eye view of a company's industry, peers, and market sentiment.
 
-Cut through the noise.`;
+Cut through the noise.
+
+P.S. Next Wednesday: a founding-member offer, waitlist-only. Watch your inbox.`;
 
 /** Signoff lines, rendered separately so the CTA button can slot above. */
 export const LAUNCH_FOUNDER_SIGNOFF = `Founder, tldrSEC


### PR DESCRIPTION
## Summary

Per the launch-sequencing decision (VRT Wed 2026-05-27 → Lifetime Wed 2026-06-03), adds a single P.S. line to the VRT founder note that primes the day-7 Lifetime ask without deflating it.

**New line at the end of `LAUNCH_FOUNDER_NOTE`:**

> P.S. Next Wednesday: a founding-member offer, waitlist-only. Watch your inbox.

## Why

The 7-day gap between VRT and Lifetime is deliberate — it aligns with the trial billing moment for `/sign-up` converters. A soft P.S. tease plants the seed for the day-7 email without revealing the price ($499), scarcity (25 seats), or specifics, so the founding offer keeps its emotional impact when it lands next Wednesday. Non-trial users get an "anticipation" cue that boosts the day-7 open rate without front-running the offer.

## What was rejected

- **No tease** — leaves day-7 conversion to surprise, but loses anticipation lift on non-trial readers.
- **Aggressive tease** — would have explicitly said "$499 lifetime seats open next Wed", which deflates the day-7 emotional moment.

## Test Coverage

- 20/20 tests pass in `__tests__/email/launch-hero-renderer.test.tsx`
- Em-dash audit still clean (uses `:` and `.`, no em-dashes)
- "Cut through the noise" still present (existing assertion)
- Multibagger paragraph still absent (existing assertion)

## Test plan

- [x] `npx jest __tests__/email/launch-hero-renderer.test.tsx` — 20 pass
- [ ] Visual verification via Tuesday's smoke-test send to internal addresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)