### PR TITLE
ci: drop paths filters from required-check workflows

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,35 +1,15 @@
 name: PR Validation Pipeline
 
 on:
+  # Jobs in this workflow are required status checks (see repo ruleset).
+  # `paths:` filters used to live here, but GitHub treats path-skipped
+  # required checks as "missing" rather than "passed" — silently blocking
+  # any PR that only touches paths outside the filter (e.g. scripts/, docs).
+  # See PR #564 for the case that surfaced it. Now runs on every PR/push.
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      # Only run on code changes, skip docs/config-only changes
-      - 'app/**'
-      - 'lib/**'
-      - 'components/**'
-      - 'services/**'
-      - 'prisma/**'
-      - 'cloudflare-cron/**'
-      - '__tests__/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'tsconfig.json'
-      - 'next.config.js'
   push:
     branches: [main]
-    paths:
-      - 'app/**'
-      - 'lib/**'
-      - 'components/**'
-      - 'services/**'
-      - 'prisma/**'
-      - 'cloudflare-cron/**'
-      - '__tests__/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'tsconfig.json'
-      - 'next.config.js'
 
 jobs:
   infrastructure-validation:

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -1,34 +1,14 @@
 name: Quality Gates
 on:
+  # Jobs in this workflow are required status checks (see repo ruleset).
+  # `paths:` filters used to live here, but GitHub treats path-skipped
+  # required checks as "missing" rather than "passed" — silently blocking
+  # any PR that only touches paths outside the filter (e.g. scripts/, docs).
+  # See PR #564 for the case that surfaced it. Now runs on every PR/push.
   push:
     branches: [main]
-    paths:
-      # Only run on code changes, skip docs/config-only changes
-      - 'app/**'
-      - 'lib/**'
-      - 'components/**'
-      - 'services/**'
-      - 'prisma/**'
-      - 'cloudflare-cron/**'
-      - '__tests__/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'tsconfig.json'
-      - 'next.config.js'
   pull_request:
     branches: [main]
-    paths:
-      - 'app/**'
-      - 'lib/**'
-      - 'components/**'
-      - 'services/**'
-      - 'prisma/**'
-      - 'cloudflare-cron/**'
-      - '__tests__/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'tsconfig.json'
-      - 'next.config.js'
 
 concurrency:
   group: quality-gates-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Problem

The repo's main-branch ruleset requires these status checks:
- Infrastructure & Code Quality
- Performance & Resource Monitoring
- Cloudflare Worker Validation
- Test Coverage (85% Minimum)
- (+ GitGuardian, Workers Builds — 3rd-party, unaffected)

All four are produced by jobs in `.github/workflows/pr-validation.yml` and `.github/workflows/quality-gates.yml`. Both workflows had `paths:` filters scoping them to code-path changes (`app/**`, `lib/**`, `__tests__/**`, etc.).

**The bug**: GitHub treats a path-skipped required check as **missing**, not **passed**. Any PR that only touches paths outside the filter becomes BLOCKED with no way to satisfy the gate short of an admin merge or a no-op commit into a watched path.

## Surfaced by

[PR #564](https://github.com/wilfred-py/tldrsec-ai/pull/564) (`feat(founding): unify region classifier`) only changed `scripts/founding/send-founding-batch.ts`. Auto-squash is enabled, all visible checks are green, but the required-checks gate will never resolve — `scripts/**` is not in the path filter, so the workflows never ran, so GitHub waits forever.

## Fix

Drop the `paths:` filters. The workflows now run on every PR/push to main.

**Cost**: ~3–4 min of compute per PR on docs/scripts-only changes (test suite + build run anyway). The workflows are idempotent.

**Benefit**: elimination of the silent-block class of bug. Any future scripts-only, docs-only, or config-only PR can be merged without admin override.

## Alternatives considered

- **Two-workflow stub pattern** (`paths` + `paths-ignore` with same job names): has an unavoidable double-trigger on mixed-paths PRs (both stub and real workflow run, both report the same check name) — causes confusion and isn't reliably interpreted by the ruleset.
- **Single workflow with `dorny/paths-filter` and an `if: always()` aggregator job**: would require restructuring both workflows and a ruleset change to require a single "all gates pass" check. More mechanically correct but a bigger surface to land.
- **Admin-merge case by case**: doesn't fix the underlying problem; same bug fires on the next scripts-only PR.

The pragmatic choice is to accept the small compute cost.

## After this lands

PR #564 needs to be re-triggered. Easiest: push an empty commit or close/reopen the PR. The new check runs will pick up the now-unfiltered required workflows.