### PR TITLE
security: address Supabase advisor findings (P0-P2)

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -87,7 +87,6 @@ jobs:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY || 'test-key' }}
           TLDRSEC_AI_SUMMARIZER: ${{ secrets.TLDRSEC_AI_SUMMARIZER || 'test-key' }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ vars.NEXT_PUBLIC_SUPABASE_URL || 'https://test.supabase.co' }}
-          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || 'test-key' }}
           SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SECRET_KEY || 'test-key' }}
           CI: true
           
@@ -112,7 +111,6 @@ jobs:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY || 'test-key' }}
           TLDRSEC_AI_SUMMARIZER: ${{ secrets.TLDRSEC_AI_SUMMARIZER || 'test-key' }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ vars.NEXT_PUBLIC_SUPABASE_URL || 'https://test.supabase.co' }}
-          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || 'test-key' }}
           SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SECRET_KEY || 'test-key' }}
           CRON_SECRET: test-secret-key
           NODE_ENV: test

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -112,7 +112,6 @@ jobs:
           NODE_ENV: test
           # Newsletter environment variables
           NEXT_PUBLIC_SUPABASE_URL: https://test.supabase.co
-          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: test-key
           SUPABASE_SECRET_KEY: test-key
         run: |
           echo "⚡ Performance benchmarks skipped (script removed in cleanup)"
@@ -147,7 +146,6 @@ jobs:
           CI: true
           # Newsletter environment variables  
           NEXT_PUBLIC_SUPABASE_URL: https://test.supabase.co
-          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: test-key
           SUPABASE_SECRET_KEY: test-key
         run: |
           echo "🧠 Memory stability test skipped (script removed in cleanup)"
@@ -200,7 +198,6 @@ jobs:
           NEXT_PRIVATE_STANDALONE: true
           # Newsletter environment variables
           NEXT_PUBLIC_SUPABASE_URL: https://test.supabase.co
-          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: test-key
           SUPABASE_SECRET_KEY: test-key
         run: |
           echo "🔨 Running build validation..."

--- a/app/api/analytics/track/route.ts
+++ b/app/api/analytics/track/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { rateLimiter } from '@/lib/security/rate-limiter';
+import { logger } from '@/lib/logging';
+
+export const dynamic = 'force-dynamic';
+
+const apiLogger = logger.child('analytics-track');
+
+async function getSupabase() {
+  const { createSupabaseServiceClient } = await import('@/lib/supabase/server-client');
+  return createSupabaseServiceClient();
+}
+
+const BodySchema = z.object({
+  page_variant: z.string().min(1).max(64),
+  visitor_id: z.string().min(1).max(64),
+  action: z.string().min(1).max(64),
+  utm_source: z.string().max(128).nullish(),
+  utm_medium: z.string().max(128).nullish(),
+  utm_campaign: z.string().max(128).nullish(),
+  referrer: z.string().max(2048).nullish(),
+});
+
+function getClientIp(request: NextRequest): string | null {
+  const fwd = request.headers.get('x-forwarded-for');
+  if (fwd) return fwd.split(',')[0]!.trim();
+  return request.headers.get('x-real-ip');
+}
+
+export async function POST(request: NextRequest) {
+  const ip = getClientIp(request) ?? 'unknown';
+
+  const rl = await rateLimiter.checkLimit('analytics-track', ip, 60, 60_000);
+  if (!rl.allowed) {
+    return NextResponse.json({ error: 'rate_limited' }, { status: 429 });
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 });
+  }
+
+  const parsed = BodySchema.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'invalid_body' }, { status: 400 });
+  }
+
+  const body = parsed.data;
+  const userAgent = request.headers.get('user-agent')?.slice(0, 512) ?? null;
+
+  try {
+    const supabase = await getSupabase();
+    const { error } = await supabase.from('page_analytics').insert({
+      page_variant: body.page_variant,
+      visitor_id: body.visitor_id,
+      action: body.action,
+      utm_source: body.utm_source ?? null,
+      utm_medium: body.utm_medium ?? null,
+      utm_campaign: body.utm_campaign ?? null,
+      user_agent: userAgent,
+      referrer: body.referrer ?? null,
+      ip_address: ip === 'unknown' ? null : ip,
+    });
+
+    if (error) {
+      apiLogger.error('insert failed', { code: error.code, message: error.message });
+      return NextResponse.json({ error: 'insert_failed' }, { status: 500 });
+    }
+  } catch (error) {
+    apiLogger.error('unhandled error', { error: error instanceof Error ? error.message : 'unknown' });
+    return NextResponse.json({ error: 'internal_error' }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/docs/deployment-checklist.md
+++ b/docs/deployment-checklist.md
@@ -11,8 +11,7 @@
 
 ### Required Supabase Variables
 - [ ] `NEXT_PUBLIC_SUPABASE_URL` set in Vercel (Production)
-- [ ] `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` set in Vercel (Production)
-- [ ] `SUPABASE_SECRET_KEY` set in Vercel (Production)
+- [ ] `SUPABASE_SECRET_KEY` set in Vercel (Production) — service-role key, server-side only
 
 ### Required Email Variables
 - [ ] `RESEND_API_KEY` set in Vercel (Production)

--- a/lib/analytics/page-tracking.ts
+++ b/lib/analytics/page-tracking.ts
@@ -1,5 +1,3 @@
-import { supabase } from '@/lib/supabase/client';
-
 export async function trackPageAnalytics(
   pageVariant: string,
   action: string,
@@ -7,51 +5,33 @@ export async function trackPageAnalytics(
     utm_source?: string | null;
     utm_medium?: string | null;
     utm_campaign?: string | null;
-    [key: string]: string | null | undefined; // Allow additional parameters for flexibility
+    [key: string]: string | null | undefined;
   }
 ) {
-  // Skip analytics in test or CI environments
   if (process.env.NODE_ENV === 'test' || process.env.CI === 'true') {
     console.log(`[Analytics] ${pageVariant}:${action}`, utmParams);
     return;
   }
 
+  if (typeof window === 'undefined') return;
+
   try {
-    await supabase.from('page_analytics').insert({
-      page_variant: pageVariant,
-      visitor_id: generateVisitorId(),
-      action,
-      utm_source: utmParams?.utm_source,
-      utm_medium: utmParams?.utm_medium,
-      utm_campaign: utmParams?.utm_campaign,
-      user_agent: typeof window !== 'undefined' ? window.navigator.userAgent : null,
-      referrer: typeof window !== 'undefined' ? document.referrer : null,
+    await fetch('/api/analytics/track', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      keepalive: true,
+      body: JSON.stringify({
+        page_variant: pageVariant,
+        visitor_id: generateVisitorId(),
+        action,
+        utm_source: utmParams?.utm_source ?? null,
+        utm_medium: utmParams?.utm_medium ?? null,
+        utm_campaign: utmParams?.utm_campaign ?? null,
+        referrer: document.referrer || null,
+      }),
     });
   } catch (error) {
     console.error('Analytics tracking error:', error);
-
-    // Track analytics failures in production
-    if (typeof window !== 'undefined' && process.env.NODE_ENV === 'production') {
-      // Send error to monitoring service (e.g., Sentry, LogRocket)
-      // This helps detect RLS policy or connectivity issues
-      try {
-        fetch('/api/monitoring/client-error', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            error: error instanceof Error ? error.message : 'Unknown error',
-            context: 'page_analytics_insert',
-            pageVariant,
-            action,
-            timestamp: new Date().toISOString()
-          })
-        }).catch(() => {
-          // Silently fail - don't break user experience
-        });
-      } catch {
-        // Double-catch to ensure no error breaks the page
-      }
-    }
   }
 }
 

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,7 +1,0 @@
-import { createClient } from '@supabase/supabase-js';
-
-// Client-side Supabase client
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://build-placeholder.supabase.co',
-  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzdXBhYmFzZSIsImlhdCI6MTY0ODc3MDQ2MCwiZXhwIjo0MTAyNDQ0ODAwLCJhdWQiOiJzdXBhYmFzZSIsInN1YiI6IjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMCIsInJvbGUiOiJhbm9uIn0.fake-key-for-build'
-);

--- a/lib/supabase/migrations/add-ip-address-to-page-analytics.sql
+++ b/lib/supabase/migrations/add-ip-address-to-page-analytics.sql
@@ -1,0 +1,9 @@
+-- Supabase advisor remediation (P0, part 1).
+--
+-- The `page_analytics` table previously allowed unrestricted browser inserts
+-- via the anon key. Step one of locking that down is adding an `ip_address`
+-- column so the server-side ingestion route can record the real client IP
+-- (taken from x-forwarded-for / x-real-ip) for abuse forensics.
+
+ALTER TABLE public.page_analytics
+  ADD COLUMN IF NOT EXISTS ip_address inet;

--- a/lib/supabase/migrations/drop-page-analytics-anon-insert-policy.sql
+++ b/lib/supabase/migrations/drop-page-analytics-anon-insert-policy.sql
@@ -1,0 +1,12 @@
+-- Supabase advisor remediation (P0, part 2).
+--
+-- Run this ONLY after /api/analytics/track is deployed and verified — once
+-- the policy is gone, the anon key can no longer insert into page_analytics
+-- and any client still calling supabase.from('page_analytics').insert(...)
+-- will start failing.
+--
+-- After this, all analytics writes go through the server-side route which
+-- uses the service-role key. RLS stays enabled with no policies, which is
+-- the same posture as the rest of the app-internal tables.
+
+DROP POLICY IF EXISTS "Allow anonymous inserts" ON public.page_analytics;

--- a/lib/supabase/migrations/harden-rls-and-function-search-paths.sql
+++ b/lib/supabase/migrations/harden-rls-and-function-search-paths.sql
@@ -1,0 +1,37 @@
+-- Supabase advisor remediation (P1 + P2).
+--
+-- P1 — `_prisma_migrations` had RLS disabled, so PostgREST exposed it to
+--      anon/authenticated roles. Prisma uses a direct Postgres connection
+--      that bypasses RLS, so enabling RLS without policies just blocks
+--      PostgREST access (which the app never used anyway).
+--
+-- P2 — Two trigger functions had a mutable search_path. Pinning to '' and
+--      schema-qualifying every reference closes the search-path injection
+--      vector flagged by the linter.
+
+ALTER TABLE public._prisma_migrations ENABLE ROW LEVEL SECURITY;
+
+ALTER FUNCTION public.notify_minion_job_change() SET search_path = '';
+
+CREATE OR REPLACE FUNCTION public.update_page_search_vector()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $function$
+DECLARE
+  timeline_text TEXT;
+BEGIN
+  SELECT coalesce(string_agg(summary || ' ' || detail, ' '), '')
+  INTO timeline_text
+  FROM public.timeline_entries
+  WHERE page_id = NEW.id;
+
+  NEW.search_vector :=
+    setweight(pg_catalog.to_tsvector('english', coalesce(NEW.title, '')), 'A') ||
+    setweight(pg_catalog.to_tsvector('english', coalesce(NEW.compiled_truth, '')), 'B') ||
+    setweight(pg_catalog.to_tsvector('english', coalesce(NEW.timeline, '')), 'C') ||
+    setweight(pg_catalog.to_tsvector('english', coalesce(timeline_text, '')), 'C');
+
+  RETURN NEW;
+END;
+$function$;

--- a/lib/supabase/server-client.ts
+++ b/lib/supabase/server-client.ts
@@ -1,35 +1,10 @@
 import { createClient } from '@supabase/supabase-js';
-import { createServerClient } from '@supabase/ssr';
-import { cookies } from 'next/headers';
 
-// Server-side Supabase client with service role for admin operations
+// Server-side Supabase client with service role for admin operations.
 export function createSupabaseServiceClient() {
   return createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://build-placeholder.supabase.co',
     // Support both SUPABASE_SERVICE_ROLE_KEY (standard) and SUPABASE_SECRET_KEY (legacy)
     process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SECRET_KEY || 'fake-service-key-for-build'
-  );
-}
-
-// Server-side Supabase client for user operations (with cookies)
-export function createServerSupabaseClient() {
-  const cookieStore = cookies();
-  
-  return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://build-placeholder.supabase.co',
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzdXBhYmFzZSIsImlhdCI6MTY0ODc3MDQ2MCwiZXhwIjo0MTAyNDQ0ODAwLCJhdWQiOiJzdXBhYmFzZSIsInN1YiI6IjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMCIsInJvbGUiOiJhbm9uIn0.fake-key-for-build',
-    {
-      cookies: {
-        get(name: string) {
-          return cookieStore.get(name)?.value;
-        },
-        set(name: string, value: string, options: unknown) {
-          cookieStore.set({ name, value, ...options });
-        },
-        remove(name: string, options: unknown) {
-          cookieStore.set({ name, value: '', ...options });
-        },
-      },
-    }
   );
 }


### PR DESCRIPTION
## Summary
- Moves browser-side `page_analytics` writes onto a server route (`/api/analytics/track`) so the Supabase anon key no longer needs INSERT into that table. New route is Zod-validated, IP-captured, rate-limited 60/min/IP via the existing `lib/security/rate-limiter`.
- Enables RLS on `_prisma_migrations` (the advisor ERROR), pins `search_path = ''` on `notify_minion_job_change` and `update_page_search_vector` (the two WARNs).
- Deletes now-unused `lib/supabase/client.ts`, slims `lib/supabase/server-client.ts`, drops `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` from CI workflows and the deploy checklist.

P3 (extensions in `public`) deferred — would require setting `search_path` on every app-facing role to keep gbrain's vector/trigram queries working. Documented in the in-tree plan.

## Migration sequencing
1. ✅ `harden-rls-and-function-search-paths.sql` — applied to prod
2. ✅ `add-ip-address-to-page-analytics.sql` — applied to prod
3. ⏳ `drop-page-analytics-anon-insert-policy.sql` — **run after this PR merges and Vercel finishes deploying**, otherwise live browsers lose analytics writes

## Test plan
- [ ] Vercel preview build succeeds
- [ ] After merge + prod deploy, `POST /api/analytics/track` returns 200 with a valid body
- [ ] After running migration 3, `mcp__supabase__get_advisors type=security` shows only the 2 deferred `extension_in_public` WARNs + the 24 by-design `rls_enabled_no_policy` INFOs

🤖 Generated with [Claude Code](https://claude.com/claude-code)