### PR TITLE
fix(launch): stringify subscriber.id for Resend tag value

### DIFF
--- a/app/api/admin/campaign/send/route.ts
+++ b/app/api/admin/campaign/send/route.ts
@@ -339,13 +339,20 @@ export async function POST(request: NextRequest) {
 
     const emails = await Promise.all(targetSubscribers.map(async subscriber => {
       const unsubscribeUrl = generateUnsubscribeUrl(subscriber.email);
+      // Resend tag values must be strings. The doc comment + TS type say
+      // subscriber.id is a UUID string, but newsletter_subscribers.id is
+      // actually a SERIAL integer in prod (see migration history). Passing
+      // a number through the resend SDK fails Zod validation with
+      // "Invalid literal value, expected \"\"". Stringify defensively
+      // regardless of underlying type.
+      const subscriberId = String(subscriber.id);
       const content = useLaunchHero && renderLaunchHero
-        ? await renderLaunchHero({ subscriberId: subscriber.id, unsubscribeUrl })
+        ? await renderLaunchHero({ subscriberId, unsubscribeUrl })
         : await getCampaignEmailContent(emailNumber, {
             unsubscribeUrl,
             variant,
             filings: filings || undefined,
-            subscriberId: subscriber.id,
+            subscriberId,
             emailId: emailTag,
           });
 
@@ -370,7 +377,7 @@ export async function POST(request: NextRequest) {
           { name: 'campaignId', value: CAMPAIGN_ID },
           { name: 'cohortId', value: cohortSlot },
           { name: 'emailId', value: emailTag },
-          { name: 'subscriberId', value: subscriber.id },
+          { name: 'subscriberId', value: subscriberId },
           { name: 'variant', value: variant || 'none' },
           // Region tag only emitted in region mode — keeps cohort-mode at the
           // locked 6-tag PostHog schema (see campaign-resend-tags.test.ts).


### PR DESCRIPTION
## What

\`subscriber.id\` is a SERIAL integer in prod, but the campaign send route assumes UUID string. Resend's Zod validator rejects integer tag values with the cryptic error \`\"Invalid literal value, expected \\\"\\\"\"\`. Result: HTTP 207 with all sends in the batch failed.

## Discovered when

Wed 27 May 07:30 UTC VRT EU broadcast fired but Resend rejected all 8 sends. Direct \`resend.emails.send\` to the same recipients with the same payload (subscriberId hardcoded as a string) works fine.

## Fix

Cast \`subscriber.id\` to \`String()\` at the top of the per-recipient map. Same value flows through to:
- \`renderLaunchHero({ subscriberId })\`
- \`getCampaignEmailContent({ subscriberId })\`
- Resend tag value

## Urgency

US batch (116 recipients) fires at 11:00 UTC via the GH Actions launch-broadcast.yml cron. Need this deployed before then.

## Test plan
- [x] Test direct send with stringified ID to wilfred.chen.python@gmail.com — Resend id \`2b7fd0b0-5ef2-4aea-bad3-9b466fd6866a\`, accepted ✓
- [ ] Merge + Vercel redeploy
- [ ] Manual workflow_dispatch for VRT EU (currently 2h+ late)
- [ ] US auto-fires at 11:00 UTC via cron

🤖 Generated with [Claude Code](https://claude.com/claude-code)