### PR TITLE
deepen: delete dead lib/db/connection.ts re-export shim

### DIFF
--- a/lib/db/connection.ts
+++ b/lib/db/connection.ts
@@ -1,9 +1,0 @@
-/**
- * Database connection compatibility layer
- * 
- * This file provides backward compatibility for imports expecting
- * the connection module. All exports are re-exported from the 
- * main prisma module to maintain consistency.
- */
-
-export { prisma, getPrismaClient } from './prisma';


### PR DESCRIPTION
## Deepening

Replaces 1 shallow Prisma re-export shim (`lib/db/connection.ts`, 8 LOC) with **no module**, because it had zero non-self callers. The hypothetical seam (1 candidate adapter, 0 callers) collapses to no seam.

## Why this is dead

`lib/db/connection.ts` re-exported `prisma` and `getPrismaClient` from `./prisma` for what its own header comment called *"backward compatibility for imports expecting the connection module."* Zero non-self imports anywhere in `app/`, `lib/`, `components/`, `services/`, or `middleware.ts`. The only references are in historical research notes under `thoughts/` and `docs/plans/actioned/` — both treat the file as backstory, not a live seam. No test file references it.

## Surviving canonical seams

Every live caller already imports from one of:

- `import { prisma } from '@/lib/db'` — the barrel re-export
- `import { getPrismaClient } from '@/lib/db/prisma'` — direct
- `import { prisma } from '../db'` — barrel via relative path

The canonical Prisma seam is `lib/db/prisma.ts` (the client factory), re-exported through `lib/db/index.ts` (the barrel). One place, one **interface**: `getPrismaClient()` + the `prisma` singleton.

## Leverage and locality

- **Leverage** callers gain: future maintainers asking *"which db module do I import — `lib/db/connection`, `lib/db/prisma`, or `lib/db`?"* now have one canonical answer. No phantom backward-compat alternative.
- **Locality** maintainers gain: the Prisma seam concentrates at one place, exactly where ADR-0004's Lifetime Seat work, the [Subscription Active] predicate in CONTEXT.md, and the recent "delete dead Secure Prisma module" (#665) PR already placed it.

## Dependency category and adapter strategy

**In-process** (per `process/Deepening/deepening.md` §1). Deletion of a non-seam — there was never a second adapter. No port to define.

## Tests deleted, tests added at the new interface

None. The shim had no test file. The canonical Prisma seam is exercised through `__tests__/lib/db/` and every Prisma-touching test.

## ADRs respected, ADRs written

Respects ADR-0001 through ADR-0006 — none reference this file. No new ADR written. Same shape as #665 (Secure Prisma) and #655 (db Resilience orbit) under the database seam.

## CONTEXT.md

No update required. No CONTEXT.md term named this shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017D6829D1b5V1Xg4qHAWMFv)_