### PR TITLE
deepen: slim environment-aware-fetcher to its used interface

### DIFF
--- a/lib/sec-edgar/environment-aware-fetcher.ts
+++ b/lib/sec-edgar/environment-aware-fetcher.ts
@@ -1,17 +1,31 @@
 /**
- * Environment-Aware SEC Filing Fetcher
- * Automatically routes to RSS (local) or REST API (production) based on environment
- * Provides unified interface for seamless integration with existing code
+ * Environment-aware [Filing] fetcher.
+ *
+ * Deep module behind a single function — `fetchCompanyFilingsUnified` — that
+ * routes a CIK or ticker to whichever SEC fetch path actually works on the
+ * current platform. Callers never branch on platform; the seam owns it.
+ *
+ * Why the routing exists at all: SEC.gov serves the same data via two paths
+ * with mutually-incompatible block patterns. Vercel can hit the RSS feeds
+ * but gets HTTP 403 on `data.sec.gov`. Railway is the inverse. Local dev
+ * uses RSS for speed and predictability. The module reads
+ * `VERCEL`/`VERCEL_URL`/`RAILWAY_ENVIRONMENT` and `NODE_ENV` to pick the
+ * working path, with `FORCE_SEC_RSS=true` / `FORCE_SEC_REST_API=true`
+ * available as kill switches when a platform's behaviour changes.
+ *
+ * `isDevelopmentEnvironment` is exported because `ticker-monitoring` uses
+ * the same dev-vs-prod signal to log differently — folding it into the
+ * fetcher's interface would require the caller to re-derive it from
+ * `process.env.NODE_ENV` every time.
  */
 
 import { logger } from '../logging';
-import { fetchSecCompanyRSS, type CompanyRSSFeed, type RSSFilingEntry } from './rss-parser';
+import { fetchSecCompanyRSS, type RSSFilingEntry } from './rss-parser';
 import { findCompanyByTicker, getCompanyFilings } from '../../services/companyService';
 import { getPrismaClient } from '../db/prisma';
 import { resolveTicker } from './cik-resolver';
 
 const envLogger = logger.child('environment-aware-fetcher');
-// Lazy accessor to avoid build-time initialization
 const getPrisma = () => getPrismaClient();
 
 export interface UnifiedFilingResponse {
@@ -24,104 +38,72 @@ export interface UnifiedFilingResponse {
   error?: string;
 }
 
-/**
- * Detect if we're running in development environment
- */
 export function isDevelopmentEnvironment(): boolean {
   return process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test';
 }
 
-/**
- * Detect if input is a CIK (numeric, 1-10 digits) or ticker symbol
- */
 function isInputCIK(input: string): boolean {
   return /^\d{1,10}$/.test(input.trim());
 }
 
-/**
- * Convert CIK to ticker using existing CIK resolver service
- */
 async function convertCIKToTicker(cik: string): Promise<string | null> {
   try {
     envLogger.debug('Converting CIK to ticker', { cik });
-    
-    // Search CikMapping database for ticker by CIK
+
     const mapping = await getPrisma().cikMapping.findFirst({
-      where: { 
-        cik: cik.padStart(10, '0'), 
-        isActive: true 
+      where: {
+        cik: cik.padStart(10, '0'),
+        isActive: true
       },
-      select: { 
+      select: {
         ticker: true,
-        companyName: true 
+        companyName: true
       }
     });
-    
+
     if (mapping?.ticker) {
-      envLogger.debug('CIK to ticker conversion successful', { 
-        cik, 
+      envLogger.debug('CIK to ticker conversion successful', {
+        cik,
         ticker: mapping.ticker,
-        companyName: mapping.companyName 
+        companyName: mapping.companyName
       });
       return mapping.ticker;
     }
-    
+
     envLogger.debug('CIK not found in mapping database', { cik });
     return null;
   } catch (error) {
-    envLogger.warn('CIK to ticker conversion failed', { 
-      cik, 
-      error: error instanceof Error ? error.message : 'Unknown error' 
+    envLogger.warn('CIK to ticker conversion failed', {
+      cik,
+      error: error instanceof Error ? error.message : 'Unknown error'
     });
     return null;
   }
 }
 
-/**
- * Detect if we should use RSS feeds 
- * Based on SEC.gov blocking behavior for different hosting providers:
- * - Local development: RSS works (fast and reliable)
- * - Vercel: RSS works, REST API blocked (HTTP 403)
- * - Railway: RSS blocked, REST API works
- */
-export function shouldUseRSSFeeds(): boolean {
-  const isDev = isDevelopmentEnvironment();
-  
-  // Allow manual override via environment variable
-  if (process.env.FORCE_SEC_REST_API === 'true') {
-    return false;
-  }
-  
-  if (process.env.FORCE_SEC_RSS === 'true') {
-    return true;
-  }
-  
-  // Platform-specific SEC.gov access patterns
-  if (process.env.VERCEL_URL || process.env.VERCEL) {
-    // Vercel: SEC Data API blocked (403), RSS feeds work
-    return true;
-  }
-  
-  if (process.env.RAILWAY_ENVIRONMENT) {
-    // Railway: RSS feeds blocked (403), REST API works
-    return false;
-  }
-  
-  // Default: RSS for development, REST API for other production environments
-  return isDev;
+// Platform routing. SEC.gov blocks different fetch paths on different hosts:
+//   - Vercel: RSS works, REST API returns 403
+//   - Railway: RSS returns 403, REST API works
+//   - Local dev: RSS works and is faster
+// FORCE_SEC_REST_API / FORCE_SEC_RSS are kill switches for when a platform
+// flips behaviour and we need to override before redeploying.
+function shouldUseRSSFeeds(): boolean {
+  if (process.env.FORCE_SEC_REST_API === 'true') return false;
+  if (process.env.FORCE_SEC_RSS === 'true') return true;
+
+  if (process.env.VERCEL_URL || process.env.VERCEL) return true;
+  if (process.env.RAILWAY_ENVIRONMENT) return false;
+
+  return isDevelopmentEnvironment();
 }
 
-/**
- * Unified filing fetcher that automatically chooses the best method based on environment
- * Maintains identical interface to existing RSS parser for backward compatibility
- */
 export async function fetchCompanyFilingsUnified(
   cikOrTicker: string,
   limit: number = 10
 ): Promise<UnifiedFilingResponse> {
   const useRSS = shouldUseRSSFeeds();
   const environment = isDevelopmentEnvironment() ? 'Development' : 'Production';
-  
+
   envLogger.info('Fetching company filings with environment-aware routing', {
     input: cikOrTicker,
     limit,
@@ -156,19 +138,14 @@ export async function fetchCompanyFilingsUnified(
   }
 }
 
-/**
- * Fetch using traditional RSS feeds (for local development)
- */
 async function fetchViaRSS(cik: string, limit: number): Promise<UnifiedFilingResponse> {
   envLogger.debug('Fetching via RSS feeds', { cik, limit });
-  
+
   try {
-    // Assume input is CIK for RSS method
     const rssData = await fetchSecCompanyRSS(cik);
-    
-    // Limit entries if requested
+
     const limitedEntries = limit > 0 ? rssData.entries.slice(0, limit) : rssData.entries;
-    
+
     return {
       success: true,
       cik: rssData.cik,
@@ -183,35 +160,29 @@ async function fetchViaRSS(cik: string, limit: number): Promise<UnifiedFilingRes
       error: error instanceof Error ? error.message : 'Unknown error'
     });
 
-    // Fallback to REST API if RSS fails
     return await fetchViaRestAPI(cik, limit);
   }
 }
 
-/**
- * Fetch using SEC EDGAR REST API (for production)
- */
 async function fetchViaRestAPI(tickerOrCik: string, limit: number): Promise<UnifiedFilingResponse> {
   envLogger.debug('Fetching via SEC EDGAR REST API', { tickerOrCik, limit });
-  
+
   let ticker: string;
-  
+
   try {
-    // Check if input is CIK or ticker and convert if necessary
     if (isInputCIK(tickerOrCik)) {
       envLogger.debug('Input detected as CIK, converting to ticker', { cik: tickerOrCik });
-      
+
       const convertedTicker = await convertCIKToTicker(tickerOrCik);
       if (!convertedTicker) {
-        // Try fallback using CIK resolver service
         envLogger.debug('Primary CIK lookup failed, trying CIK resolver service');
-        
+
         const resolverResult = await resolveTicker(tickerOrCik);
         if (resolverResult.success && resolverResult.ticker) {
           ticker = resolverResult.ticker;
-          envLogger.debug('CIK resolver fallback succeeded', { 
-            cik: tickerOrCik, 
-            ticker: resolverResult.ticker 
+          envLogger.debug('CIK resolver fallback succeeded', {
+            cik: tickerOrCik,
+            ticker: resolverResult.ticker
           });
         } else {
           return {
@@ -226,28 +197,25 @@ async function fetchViaRestAPI(tickerOrCik: string, limit: number): Promise<Unif
         }
       } else {
         ticker = convertedTicker;
-        envLogger.debug('Successfully converted CIK to ticker', { 
-          cik: tickerOrCik, 
-          ticker: convertedTicker 
+        envLogger.debug('Successfully converted CIK to ticker', {
+          cik: tickerOrCik,
+          ticker: convertedTicker
         });
       }
     } else {
-      // Input is already a ticker symbol
       ticker = tickerOrCik;
       envLogger.debug('Input detected as ticker symbol', { ticker });
     }
-    
-    // Log parameter processing details for debugging
+
     envLogger.debug('Parameter processing completed', {
       originalInput: tickerOrCik,
       inputType: isInputCIK(tickerOrCik) ? 'CIK' : 'ticker',
       finalTicker: ticker,
       conversionRequired: isInputCIK(tickerOrCik)
     });
-    
-    // Now use ticker (not CIK) with findCompanyByTicker
+
     const company = await findCompanyByTicker(ticker);
-    
+
     if (!company) {
       return {
         success: false,
@@ -259,10 +227,9 @@ async function fetchViaRestAPI(tickerOrCik: string, limit: number): Promise<Unif
         error: `Company not found for ticker: ${ticker} (original input: ${tickerOrCik})`
       };
     }
-    
+
     const filingsResult = await getCompanyFilings(company);
-    
-    // Convert SecFiling[] to RSSFilingEntry[] format
+
     const limitedFilings = limit > 0 ? filingsResult.recentFilings.slice(0, limit) : filingsResult.recentFilings;
     const entries: RSSFilingEntry[] = limitedFilings.map(filing => ({
       accessionNumber: filing.accessionNumber,
@@ -272,7 +239,7 @@ async function fetchViaRestAPI(tickerOrCik: string, limit: number): Promise<Unif
       rssEntryDate: new Date(filing.filingDate),
       title: `${filing.form} - ${company.name}`
     }));
-    
+
     return {
       success: true,
       cik: company.cik,
@@ -295,109 +262,6 @@ async function fetchViaRestAPI(tickerOrCik: string, limit: number): Promise<Unif
       entries: [],
       lastUpdated: new Date(),
       source: 'rest-api',
-      error: error instanceof Error ? error.message : 'Unknown error'
-    };
-  }
-}
-
-/**
- * Batch fetch filings for multiple tickers/CIKs with environment awareness
- */
-export async function fetchMultipleCompanyFilingsUnified(
-  inputs: string[], 
-  limit: number = 5
-): Promise<Map<string, UnifiedFilingResponse>> {
-  const results = new Map<string, UnifiedFilingResponse>();
-  const useRSS = shouldUseRSSFeeds();
-  
-  envLogger.info('Batch fetching company filings', {
-    inputCount: inputs.length,
-    limit,
-    useRSS,
-    environment: isDevelopmentEnvironment() ? 'Development' : 'Production'
-  });
-
-  // Process with appropriate concurrency based on source
-  const BATCH_SIZE = useRSS ? 2 : 3; // RSS is more restrictive
-  
-  for (let i = 0; i < inputs.length; i += BATCH_SIZE) {
-    const batch = inputs.slice(i, i + BATCH_SIZE);
-    
-    const batchPromises = batch.map(async (input) => {
-      const result = await fetchCompanyFilingsUnified(input, limit);
-      return { input, result };
-    });
-
-    const batchResults = await Promise.all(batchPromises);
-    
-    for (const { input, result } of batchResults) {
-      results.set(input, result);
-    }
-    
-    // Pause between batches to respect rate limits
-    if (i + BATCH_SIZE < inputs.length) {
-      const delay = useRSS ? 1000 : 200; // RSS needs more time
-      await new Promise(resolve => setTimeout(resolve, delay));
-    }
-  }
-  
-  envLogger.info('Completed batch filing fetch', {
-    processedInputs: results.size,
-    successCount: Array.from(results.values()).filter(r => r.success).length,
-    totalFilings: Array.from(results.values()).reduce((sum, r) => sum + r.entries.length, 0)
-  });
-  
-  return results;
-}
-
-/**
- * Health check function to test the current environment's filing fetch capability
- */
-export async function testEnvironmentFilingFetch(): Promise<{
-  success: boolean;
-  environment: string;
-  method: string;
-  testResults: {
-    canReachSEC: boolean;
-    rssWorking?: boolean;
-    restApiWorking?: boolean;
-  };
-  error?: string;
-}> {
-  const useRSS = shouldUseRSSFeeds();
-  const environment = isDevelopmentEnvironment() ? 'Development' : 'Production';
-  
-  envLogger.info('Testing environment filing fetch capability', {
-    environment,
-    method: useRSS ? 'RSS' : 'REST API'
-  });
-
-  try {
-    // Test with Tesla (CIK: 1318605) - a well-known company
-    const testInput = useRSS ? '1318605' : 'TSLA';
-    const result = await fetchCompanyFilingsUnified(testInput, 1);
-    
-    return {
-      success: result.success,
-      environment,
-      method: useRSS ? 'RSS' : 'REST API',
-      testResults: {
-        canReachSEC: result.success,
-        rssWorking: useRSS ? result.success : undefined,
-        restApiWorking: !useRSS ? result.success : undefined
-      },
-      error: result.error
-    };
-  } catch (error) {
-    return {
-      success: false,
-      environment,
-      method: useRSS ? 'RSS' : 'REST API',
-      testResults: {
-        canReachSEC: false,
-        rssWorking: useRSS ? false : undefined,
-        restApiWorking: !useRSS ? false : undefined
-      },
       error: error instanceof Error ? error.message : 'Unknown error'
     };
   }


### PR DESCRIPTION
Narrows the environment-aware Filing fetcher's interface from 7 exports to 2 by deleting unreachable code. One deep module behind the production-used pair `fetchCompanyFilingsUnified` + `isDevelopmentEnvironment`, with platform routing folded back behind the seam.

## Deepening

The module previously presented 7 entry points (`fetchCompanyFilingsUnified`, `fetchMultipleCompanyFilingsUnified`, `testEnvironmentFilingFetch`, `isDevelopmentEnvironment`, `shouldUseRSSFeeds`, `UnifiedFilingResponse`, plus implicit `CompanyRSSFeed` re-export). The only caller — `lib/sec-edgar/ticker-monitoring.ts` — uses two: `fetchCompanyFilingsUnified` and `isDevelopmentEnvironment`.

After this PR, the seam exposes exactly those two functions plus the `UnifiedFilingResponse` type. The platform-routing decision (Vercel uses RSS because `data.sec.gov` returns 403; Railway uses the REST API because RSS returns 403; local dev uses RSS for speed) now lives entirely inside the implementation. Callers no longer have a way to learn about it — that's the point.

## Leverage and locality

**Leverage**: one caller stays one caller, but it now has fewer entry points to choose between. A future second adapter (a script that needs to fetch one filer's recent filings) inherits the same single function.

**Locality**: the routing knobs (`FORCE_SEC_RSS`, `FORCE_SEC_REST_API`, `VERCEL_URL`, `RAILWAY_ENVIRONMENT`, `NODE_ENV` reads) are now interior to one module. When the platform's block behaviour next flips, a maintainer changes one private function. Today, the public `shouldUseRSSFeeds` invited divergence — any other caller could read the env vars directly and disagree with the seam's verdict.

## What was deleted

| Export | Status | Why |
|--------|--------|-----|
| `fetchMultipleCompanyFilingsUnified` | deleted | 0 callers in `lib/`, `app/`, `services/`, `__tests__/`, `tests/`, or `scripts/` |
| `testEnvironmentFilingFetch` | deleted | 0 callers anywhere; was a health-check helper that no health endpoint ever wired up |
| `shouldUseRSSFeeds` | demoted to private | only called inside the module (by `fetchCompanyFilingsUnified` and by the two deleted dead exports) |

Module shrinks 403 → 268 LOC. Interface shrinks 7 → 3.

## Dependency category

**In-process** per `process/Deepening/deepening.md` §1. The seam owns pure routing logic; the actual SEC fetches live behind sub-modules (`./rss-parser`, `../../services/companyService`, `./cik-resolver`) that already have their own seams. No new adapter introduced.

## Tests deleted / added

None. No test file referenced any of the deleted exports — `grep -rln 'fetchMultipleCompanyFilingsUnified\|testEnvironmentFilingFetch\|shouldUseRSSFeeds' __tests__/ tests/` returned zero results before this PR. The one indirect downstream test (`__tests__/cron/handlers/discovery-unprocessed.test.ts`) still passes.

## ADRs

- Respects ADR-0001 (no module-load-order surprises): nothing about filing-type registration changes.
- Respects ADR-0005 (HTML iXBRL as primary): this seam is at the filing **discovery** layer, upstream of any iXBRL parsing.
- No ADR contradicted, no ADR written.

This is a nightly-deepen routine PR. Draft for human review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNnF4ggk35FjFQ1q7TsUv9)_