### PR TITLE
deepen: slim CronSecFilingService to its one used method

### DIFF
--- a/lib/cron/sec-filing-service.ts
+++ b/lib/cron/sec-filing-service.ts
@@ -1,50 +1,35 @@
 /**
- * SEC Filing monitoring service for cron jobs
- * Handles RSS feed monitoring, filing discovery, and ticker validation
- * Extracted from app/api/cron/tier-aware/route.ts
+ * Cron [Filing] discovery.
+ *
+ * Deep module behind one function — `CronSecFilingService.checkForNewFilings` —
+ * that walks a batch of tickers, resolves each one's `TickerMonitoring` row,
+ * and returns the new [Filing]s observed since the last RSS check. Called by
+ * `lib/cron/handlers/discovery-handler.ts`; no other production caller.
+ *
+ * The static-class shape is retained so the caller's existing
+ * `CronSecFilingService.checkForNewFilings(...)` invocation site doesn't
+ * have to change.
+ *
+ * Previously the same class exported 9 additional methods
+ * (`runSecFilingMonitoring`, `validateUserTickersForProcessing`,
+ * `getUnprocessedFilingsForUser`, `markFilingAsProcessed`,
+ * `getFilingProcessingMetrics`, `shouldProcessFiling`,
+ * `getFilingPriority`, `validateFilingData`, `getMonitoringSummary`)
+ * plus the private helpers they leaned on. None of those nine had a
+ * production caller; `runSecFilingMonitoring` was only mocked by two
+ * test files (`__tests__/timeout/timeout-scenarios.test.ts` — already
+ * fails to load because `../../lib/cron/user-processing-service` doesn't
+ * exist — and `__tests__/cron/comprehensive-cron-integration.test.ts` —
+ * 27 of 28 suites already failing). The shallow interface was inviting
+ * future callers to wire up to methods that hadn't been alive in months;
+ * deleting them concentrates the cron discovery seam on its actual job.
  */
 
 import { logger } from '../logging';
-import { CronJobMonitor } from '../monitoring/cron-monitor';
-import { 
-  getActiveTickersForMonitoring, 
-  checkTickerForNewFilings,
-  validateUserTickers,
-  getUnprocessedFilingsForTicker,
-  markFilingAsProcessedByAccession
-} from '../sec-edgar/ticker-monitoring';
-// import type { DatabaseUser } from './types';
-import { MAX_CONCURRENT_RSS_CHECKS, RSS_STAGGER_DELAY_MS } from './types';
+import { checkTickerForNewFilings } from '../sec-edgar/ticker-monitoring';
 
 const filingLogger = logger.child('cron-sec-filing');
 
-interface TickerMonitoring {
-  id: string;
-  symbol: string;
-  cik: string;
-  companyName: string;
-  isActive: boolean;
-  rssUrl: string;
-  subscriberCount: number;
-}
-
-interface FilingInfo {
-  id: string;
-  accessionNumber: string;
-  filingType: string;
-  filingDate: Date;
-  filingUrl: string;
-}
-
-interface TickerValidation {
-  symbol: string;
-  valid: boolean;
-  cik?: string;
-  companyName?: string;
-  error?: string;
-}
-
-// Interface for filing with ticker context (used by discovery handler)
 export interface FilingWithTicker {
   id: string;
   accessionNumber: string;
@@ -57,16 +42,14 @@ export interface FilingWithTicker {
 
 export class CronSecFilingService {
   /**
-   * Check for new filings across tickers
-   * Used by discovery-handler to find new filings across all tracked tickers
+   * Walk a list of tickers and return any new [Filing]s observed since each
+   * ticker's last RSS check. Tickers without a CIK or without a
+   * `TickerMonitoring` row are skipped silently; failures on one ticker
+   * never abort the loop.
    *
    * Supports two modes:
-   * 1. User-centric: Pass userId for user-specific discovery (legacy)
-   * 2. Ticker-centric: Pass null for userId for multi-user discovery (preferred)
-   *
-   * @param tickers - Array of tickers with basic info
-   * @param userId - The user ID (for logging) - null for ticker-centric discovery
-   * @returns Array of new filings with ticker context
+   * 1. User-centric: Pass `userId` for user-specific discovery (legacy)
+   * 2. Ticker-centric: Pass `null` for `userId` for multi-user discovery (preferred)
    */
   static async checkForNewFilings(
     tickers: Array<{ id: string; symbol: string; companyName: string | null; cik: string | null }>,
@@ -77,13 +60,11 @@ export class CronSecFilingService {
 
     for (const tickerItem of tickers) {
       try {
-        // Skip tickers without CIK
         if (!tickerItem.cik) {
           filingLogger.debug(`Skipping ticker ${tickerItem.symbol} - no CIK`, logContext);
           continue;
         }
 
-        // Look up TickerMonitoring record to get full ActiveTicker info
         const { getPrismaClient } = await import('../db/prisma');
         const prisma = getPrismaClient();
 
@@ -96,7 +77,6 @@ export class CronSecFilingService {
           continue;
         }
 
-        // Convert to ActiveTicker format expected by checkTickerForNewFilings
         const activeTicker = {
           id: tickerMonitoring.id,
           cik: tickerMonitoring.cik,
@@ -105,10 +85,9 @@ export class CronSecFilingService {
           rssUrl: tickerMonitoring.rssUrl || '',
           lastChecked: tickerMonitoring.lastChecked,
           lastAccessionSeen: tickerMonitoring.lastAccessionSeen,
-          subscriberCount: 1 // Not critical for this use case
+          subscriberCount: 1
         };
 
-        // Check for new filings using the existing function
         const newFilings = await checkTickerForNewFilings(activeTicker);
 
         filingLogger.debug(`Checked ${tickerItem.symbol} for new filings`, {
@@ -117,7 +96,6 @@ export class CronSecFilingService {
           newFilingsFound: newFilings.length
         });
 
-        // Convert RSSFilingEntry to FilingWithTicker format
         for (const filing of newFilings) {
           allNewFilings.push({
             id: `${tickerItem.symbol}-${filing.accessionNumber}`,
@@ -135,7 +113,6 @@ export class CronSecFilingService {
           ticker: tickerItem.symbol,
           error: error instanceof Error ? error.message : 'Unknown error'
         });
-        // Continue with other tickers
       }
     }
 
@@ -147,395 +124,5 @@ export class CronSecFilingService {
     });
 
     return allNewFilings;
-  }
-
-  /**
-   * Core SEC filing monitoring - runs continuously regardless of market hours
-   * SEC filings can be published 24/7 including weekends and holidays
-   */
-  static async runSecFilingMonitoring(monitor?: CronJobMonitor): Promise<{
-    tickersChecked: number;
-    newFilingsFound: number;
-    errors: number;
-  }> {
-    try {
-      filingLogger.info('Starting core SEC filing monitoring phase');
-      
-      // Phase 1: Check for new filings via RSS feeds
-      const activeTickers = await getActiveTickersForMonitoring();
-      
-      if (activeTickers.length === 0) {
-        filingLogger.info('No active tickers to monitor');
-        return {
-          tickersChecked: 0,
-          newFilingsFound: 0,
-          errors: 0
-        };
-      }
-      
-      filingLogger.info(`Monitoring ${activeTickers.length} active tickers for new SEC filings`);
-      
-      let newFilingsFound = 0;
-      let errorCount = 0;
-      
-      // Process tickers in batches to avoid overwhelming SEC servers
-      const batches = this.createTickerBatches(activeTickers, MAX_CONCURRENT_RSS_CHECKS);
-      
-      for (const batch of batches) {
-        const batchResults = await this.processBatchOfTickers(batch, monitor);
-        newFilingsFound += batchResults.newFilingsFound;
-        errorCount += batchResults.errors;
-        
-        // Brief pause between batches to be respectful to SEC servers
-        if (batches.indexOf(batch) < batches.length - 1) {
-          await this.delay(1000);
-        }
-      }
-      
-      // Update monitoring metrics
-      if (monitor) {
-        await monitor.updateMetrics({
-          tickersChecked: activeTickers.length,
-          newFilingsFound,
-          errorCount
-        });
-      }
-      
-      filingLogger.info('SEC filing RSS monitoring completed', {
-        tickersChecked: activeTickers.length,
-        newFilingsFound,
-        errors: errorCount
-      });
-      
-      return {
-        tickersChecked: activeTickers.length,
-        newFilingsFound,
-        errors: errorCount
-      };
-      
-    } catch (error) {
-      filingLogger.error('SEC filing monitoring failed', { error });
-      if (monitor) await monitor.updateMetrics({ errorCount: 1 });
-      throw error;
-    }
-  }
-
-  /**
-   * Validate user tickers and return valid ones with CIK information
-   */
-  static async validateUserTickersForProcessing(
-    userId: string,
-    userTickers: Array<{ symbol: string; [key: string]: unknown }>
-  ): Promise<TickerValidation[]> {
-    try {
-      if (!userTickers || userTickers.length === 0) {
-        filingLogger.warn(`No tickers found for user ${userId}`);
-        return [];
-      }
-
-      filingLogger.debug(`Validating ${userTickers.length} tickers for user ${userId}`);
-
-      const tickerValidations = await validateUserTickers(userId, userTickers);
-      
-      const validTickers = (tickerValidations || []).filter(t => t && t.valid);
-      const invalidTickers = (tickerValidations || []).filter(t => t && !t.valid);
-
-      if (invalidTickers.length > 0) {
-        filingLogger.warn(`Some tickers invalid for user ${userId}`, {
-          userId,
-          validCount: validTickers.length,
-          totalCount: userTickers.length,
-          invalidTickers: invalidTickers.map(t => t.symbol).filter(Boolean)
-        });
-      }
-
-      filingLogger.info(`Validated tickers for user ${userId}`, {
-        totalTickers: userTickers.length,
-        validTickers: validTickers.length,
-        invalidTickers: invalidTickers.length
-      });
-
-      return tickerValidations || [];
-
-    } catch (error) {
-      filingLogger.error(`Failed to validate tickers for user ${userId}`, {
-        error: error instanceof Error ? error.message : 'Unknown validation error',
-        userId,
-        tickerCount: userTickers?.length || 0
-      });
-      return [];
-    }
-  }
-
-  /**
-   * Get unprocessed filings for a specific ticker and user
-   */
-  static async getUnprocessedFilingsForUser(
-    tickerSymbol: string,
-    userId: string
-  ): Promise<FilingInfo[]> {
-    try {
-      filingLogger.debug(`Getting unprocessed filings for ${tickerSymbol} and user ${userId}`);
-
-      const unprocessedFilings = await getUnprocessedFilingsForTicker(tickerSymbol, userId);
-
-      if (!Array.isArray(unprocessedFilings)) {
-        filingLogger.error(`Invalid response from getUnprocessedFilingsForTicker for ${tickerSymbol}`, {
-          userId,
-          ticker: tickerSymbol,
-          responseType: typeof unprocessedFilings,
-          response: unprocessedFilings
-        });
-        return [];
-      }
-
-      filingLogger.info(`Found ${unprocessedFilings.length} unprocessed filings for ${tickerSymbol}`, {
-        userId,
-        filingsFound: (unprocessedFilings || []).map(f => ({
-          accession: f?.accessionNumber || 'unknown',
-          type: f?.filingType || 'unknown',
-          date: f?.filingDate || 'unknown'
-        })).filter(f => f.accession !== 'unknown')
-      });
-
-      return unprocessedFilings.map(filing => ({
-        id: filing.id,
-        accessionNumber: filing.accessionNumber,
-        filingType: filing.filingType,
-        filingDate: filing.filingDate,
-        filingUrl: filing.filingUrl || ''
-      }));
-
-    } catch (error) {
-      filingLogger.error(`Failed to get unprocessed filings for ${tickerSymbol}`, {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        userId,
-        ticker: tickerSymbol,
-        errorStack: error instanceof Error ? error.stack : undefined
-      });
-      return [];
-    }
-  }
-
-  /**
-   * Mark a filing as processed after successful processing
-   */
-  static async markFilingAsProcessed(
-    accessionNumber: string,
-    tickerSymbol: string,
-    userId: string
-  ): Promise<void> {
-    try {
-      await markFilingAsProcessedByAccession(accessionNumber, tickerSymbol, userId);
-      filingLogger.debug(`Marked filing as processed: ${accessionNumber} for ${tickerSymbol}`, {
-        userId
-      });
-    } catch (error) {
-      // Log error but don't fail the entire processing - the filing was successfully processed
-      filingLogger.warn(`Failed to mark filing as processed, but filing processing was successful`, {
-        filingId: accessionNumber,
-        userId,
-        ticker: tickerSymbol,
-        error: error instanceof Error ? error.message : 'Unknown error'
-      });
-    }
-  }
-
-  /**
-   * Get filing processing metrics for monitoring
-   */
-  static async getFilingProcessingMetrics(
-    tickerSymbol: string,
-    userId: string
-  ): Promise<{
-    totalFilings: number;
-    processedFilings: number;
-    pendingFilings: number;
-    lastProcessedDate?: Date;
-  }> {
-    try {
-      // This would require additional database queries
-      // For now, return basic metrics structure
-      return {
-        totalFilings: 0,
-        processedFilings: 0,
-        pendingFilings: 0
-      };
-    } catch (error) {
-      filingLogger.error('Failed to get filing processing metrics', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        tickerSymbol,
-        userId
-      });
-      return {
-        totalFilings: 0,
-        processedFilings: 0,
-        pendingFilings: 0
-      };
-    }
-  }
-
-  /**
-   * Create batches of tickers for concurrent processing
-   */
-  private static createTickerBatches<T>(
-    tickers: T[],
-    batchSize: number
-  ): T[][] {
-    const batches: T[][] = [];
-    for (let i = 0; i < tickers.length; i += batchSize) {
-      batches.push(tickers.slice(i, i + batchSize));
-    }
-    return batches;
-  }
-
-  /**
-   * Process a batch of tickers for new filings
-   */
-  private static async processBatchOfTickers(
-    batch: TickerMonitoring[],
-    monitor?: CronJobMonitor
-  ): Promise<{ newFilingsFound: number; errors: number }> {
-    let newFilingsFound = 0;
-    let errors = 0;
-
-    // Stagger RSS checks within batch to avoid SEC rate limit bursts
-    // Each check launches 200ms after the previous one
-    const batchPromises = batch.map((ticker, i) => {
-      return new Promise<void>(resolve => setTimeout(resolve, i * RSS_STAGGER_DELAY_MS))
-        .then(async () => {
-          try {
-            const newFilings = await checkTickerForNewFilings(ticker);
-            const filingsCount = newFilings.length;
-            newFilingsFound += filingsCount;
-
-            filingLogger.debug(`Checked ${ticker.symbol}: ${filingsCount} new filings`);
-
-            return { filingsFound: filingsCount, error: null };
-          } catch (error) {
-            filingLogger.error(`Failed to check ticker ${ticker.symbol}`, { error });
-            if (monitor) await monitor.updateMetrics({ errorCount: 1 });
-            errors++;
-            return { filingsFound: 0, error };
-          }
-        });
-    });
-
-    const results = await Promise.allSettled(batchPromises);
-    
-    // Aggregate results from settled promises
-    for (const result of results) {
-      if (result.status === 'fulfilled' && result.value) {
-        if (result.value.error) {
-          errors++;
-        } else {
-          newFilingsFound += result.value.filingsFound;
-        }
-      } else {
-        errors++;
-      }
-    }
-
-    return { newFilingsFound, errors };
-  }
-
-  /**
-   * Helper function to create delays between batch processing
-   */
-  private static delay(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
-  }
-
-  /**
-   * Check if a filing should be processed based on form type and other criteria
-   */
-  static shouldProcessFiling(
-    filingType: string,
-    filingDate: Date,
-    userPreferences?: {
-      excludedFormTypes?: string[];
-      minFilingAge?: number; // in hours
-    }
-  ): boolean {
-    // Exclude certain form types if specified
-    if (userPreferences?.excludedFormTypes?.includes(filingType.toUpperCase())) {
-      return false;
-    }
-
-    // Check minimum filing age if specified
-    if (userPreferences?.minFilingAge) {
-      const ageInHours = (Date.now() - filingDate.getTime()) / (1000 * 60 * 60);
-      if (ageInHours < userPreferences.minFilingAge) {
-        return false;
-      }
-    }
-
-    // Common form types that are typically processed
-    const processableFormTypes = [
-      '10-K', '10-Q', '8-K', 'DEF 14A', 'FORM 4', 'SC 13D', 'SC 13G',
-      '10-K/A', '10-Q/A', '8-K/A', 'FORM 144'
-    ];
-
-    return processableFormTypes.includes(filingType.toUpperCase());
-  }
-
-  /**
-   * Get filing priority based on form type (for processing order)
-   */
-  static getFilingPriority(filingType: string): number {
-    const priorities: Record<string, number> = {
-      '8-K': 1,     // Highest priority - current reports
-      'FORM 4': 2,  // Insider trading reports
-      '10-Q': 3,    // Quarterly reports
-      '10-K': 4,    // Annual reports
-      'DEF 14A': 5, // Proxy statements
-      'SC 13D': 6,  // Beneficial ownership reports
-      'SC 13G': 7,  // Beneficial ownership reports (passive)
-      'FORM 144': 8, // Notice of proposed sale
-    };
-
-    return priorities[filingType.toUpperCase()] || 9; // Default to lowest priority
-  }
-
-  /**
-   * Validate filing data structure
-   */
-  static validateFilingData(filing: unknown): filing is FilingInfo {
-    if (!filing || typeof filing !== 'object') return false;
-    
-    const f = filing as Record<string, unknown>;
-    return (
-      typeof f.id === 'string' &&
-      typeof f.accessionNumber === 'string' &&
-      typeof f.filingType === 'string' &&
-      f.filingDate instanceof Date &&
-      (typeof f.filingUrl === 'string' || f.filingUrl === undefined)
-    );
-  }
-
-  /**
-   * Get summary of filing monitoring status
-   */
-  static async getMonitoringSummary(): Promise<{
-    activeTickers: number;
-    totalFilingsToday: number;
-    processingErrors: number;
-  }> {
-    try {
-      const activeTickers = await getActiveTickersForMonitoring();
-      
-      return {
-        activeTickers: activeTickers.length,
-        totalFilingsToday: 0, // Would require additional database query
-        processingErrors: 0   // Would require error tracking
-      };
-    } catch (error) {
-      filingLogger.error('Failed to get monitoring summary', { error });
-      return {
-        activeTickers: 0,
-        totalFilingsToday: 0,
-        processingErrors: 1
-      };
-    }
   }
 }


### PR DESCRIPTION
Narrows the cron [Filing]-discovery seam from a 10-method static class to its one production method. `checkForNewFilings` is the only entry point a caller (or a future caller) should learn.

## Deepening

`CronSecFilingService` previously presented 10 static methods. `lib/cron/handlers/discovery-handler.ts` uses exactly one: `checkForNewFilings`. The other nine had **zero** production callers:

| Method | Prod callers | Test references |
|--------|--------------|-----------------|
| `checkForNewFilings` | 1 (discovery-handler) | covered via discovery-handler tests |
| `runSecFilingMonitoring` | 0 | 2 mock factories in already-broken tests |
| `validateUserTickersForProcessing` | 0 | 0 |
| `getUnprocessedFilingsForUser` | 0 | 0 |
| `markFilingAsProcessed` | 0 | 0 |
| `getFilingProcessingMetrics` | 0 | 0 |
| `shouldProcessFiling` | 0 | 0 |
| `getFilingPriority` | 0 | 0 |
| `validateFilingData` | 0 | 0 |
| `getMonitoringSummary` | 0 | 0 |

The private helpers (`createTickerBatches`, `processBatchOfTickers`, `delay`) existed only to serve the dead `runSecFilingMonitoring`, so they go too.

## Leverage and locality

**Leverage**: the one method that ships is the one method to read, mock, or extend. A future second caller (a backfill script that wants to walk a CIK list) finds `checkForNewFilings` and stops looking. Today a future caller has to ask "is `runSecFilingMonitoring` alive? what about `getMonitoringSummary`?" and grep to find out.

**Locality**: cron-discovery behaviour now concentrates at one method. When the rate-limit budget or per-ticker error policy needs to change, a maintainer edits 60 LOC instead of scanning 540.

## Stale test mocks

Both files that still reference `runSecFilingMonitoring` are already broken:

- `__tests__/timeout/timeout-scenarios.test.ts` fails to load — `jest.mock('../../lib/cron/user-processing-service', ...)` resolves to a module that doesn't exist on `main`.
- `__tests__/cron/comprehensive-cron-integration.test.ts` runs **27 of 28** suites failing on `main` for unrelated jsdom/URL setup reasons; the `runSecFilingMonitoring` mock factory still parses but the assertions that would call it never reach.

This PR does not touch those mocks. The deletion doesn't change their pass rate (0/28 broken → 0/28 broken). Cleaning them is in scope for a separate "delete broken legacy tests" PR.

## Dependency category

**In-process** per `process/Deepening/deepening.md` §1. The seam consumes one in-process helper (`checkTickerForNewFilings` from `lib/sec-edgar/ticker-monitoring`) and Prisma. No new adapter introduced.

## Tests deleted / added

- **Deleted**: none.
- **Added**: none.
- **Re-verified**: `__tests__/cron/handlers/` — 8 suites, 60 tests, all passing.

The interface coverage for `checkForNewFilings` was always at the discovery-handler seam (`__tests__/cron/handlers/discovery-unprocessed.test.ts`), not at the static class — those tests still pass without modification.

## ADRs

- No ADR contradicted, no ADR written. The cron-discovery handler architecture itself is unchanged.

Module shrinks 540 → 128 LOC. Interface shrinks 10 methods → 1.

Nightly-deepen routine PR. Draft for human review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNnF4ggk35FjFQ1q7TsUv9)_