### PR TITLE
deepen: delete dead completeOnboarding legacy entry point

### DIFF
--- a/app/(auth)/onboarding/actions.ts
+++ b/app/(auth)/onboarding/actions.ts
@@ -160,144 +160,19 @@ export async function addTickerSubscription(subscription: {
 /**
  * Complete the onboarding process and send welcome email
  */
-export async function completeOnboarding(): Promise<{ success: boolean; error?: string }> {
-  try {
-    // Get auth user data
-    const { userId } = await auth();
-    
-    if (!userId) {
-      return { success: false, error: 'User not authenticated' };
-    }
-    
-    // Get user details from Clerk
-    const user = await currentUser();
-    if (!user || !user.emailAddresses || user.emailAddresses.length === 0) {
-      return { success: false, error: 'User email not available' };
-    }
-    
-    const primaryEmail = user.emailAddresses[0].emailAddress;
-    const userName = user.firstName ? `${user.firstName} ${user.lastName || ''}`.trim() : 'User';
-    
-    // Check if user exists in database by both authProviderId and email
-    let dbUser = await getPrismaClient().user.findFirst({
-      where: {
-        OR: [
-          { authProviderId: userId },
-          { email: primaryEmail }
-        ]
-      }
-    });
-
-    // If user doesn't exist yet, create a new user record
-    if (!dbUser) {
-      console.log(`Creating new user during onboarding for ${primaryEmail}`);
-
-      // Convert preferences to plain JSON object for database storage
-      const defaultPreferences = {
-        notifications: JSON.parse(JSON.stringify(DEFAULT_NOTIFICATION_PREFERENCES)),
-        ui: JSON.parse(JSON.stringify(DEFAULT_UI_PREFERENCES))
-      };
-
-      try {
-        dbUser = await getPrismaClient().user.create({
-          data: {
-            email: primaryEmail,
-            authProvider: 'clerk',
-            authProviderId: userId,
-            name: userName,
-            preferences: defaultPreferences,
-            onboardingCompleted: true
-          }
-        });
-
-        console.log(`Created new user in database during onboarding: ${dbUser.id}`);
-      } catch (createError) {
-        console.error('Failed to create user in database:', createError);
-        return {
-          success: false,
-          error: createError instanceof Error ? createError.message : 'Failed to create user in database'
-        };
-      }
-    }
-
-    // Ensure onboardingCompleted is set to true in the database
-    if (dbUser && !dbUser.onboardingCompleted) {
-      await getPrismaClient().user.update({
-        where: { id: dbUser.id },
-        data: { onboardingCompleted: true }
-      });
-      console.log(`Set onboardingCompleted=true for user ${dbUser.id}`);
-    }
-
-    // Sync onboardingCompleted to Clerk publicMetadata
-    try {
-      const client = await clerkClient();
-      await client.users.updateUserMetadata(userId, {
-        publicMetadata: { onboardingCompleted: true }
-      });
-      console.log(`Synced onboardingCompleted=true to Clerk metadata for user ${userId}`);
-    } catch (metadataError) {
-      console.error('Failed to sync onboardingCompleted to Clerk:', metadataError);
-      // Continue even if Clerk sync fails - the database is the source of truth
-    }
-    
-    // Send welcome email with proper error handling
-    try {
-      const emailResult = await sendWelcomeEmail();
-
-      if (!emailResult.success) {
-        console.warn('Failed to send welcome email:', emailResult.error);
-        // Continue even if email fails - don't block the user
-      } else {
-        console.log(`Welcome email sent successfully to ${primaryEmail}`);
-      }
-    } catch (emailError) {
-      console.error('Exception when sending welcome email:', emailError);
-      // Continue even if email fails - don't block the user
-    }
-
-    // Reconcile Stripe subscription (fire-and-forget)
-    // Always attempt — handles re-onboarded users whose Stripe sub still exists
-    if (dbUser) {
-      import('@/lib/stripe/reconcile')
-        .then(({ reconcileStripeSubscription }) =>
-          reconcileStripeSubscription(dbUser.id, primaryEmail)
-        )
-        .then((reconcileResult) => {
-          if (reconcileResult.reconciled) {
-            console.log(`[Onboarding] Reconciled Stripe subscription: ${reconcileResult.planType}`);
-          }
-        })
-        .catch((reconcileError) => {
-          console.error('[Onboarding] Stripe reconciliation failed:', reconcileError);
-        });
-    }
-
-    revalidatePath('/onboarding');
-    revalidatePath('/dashboard');
-    return { success: true };
-  } catch (error) {
-    console.error('Failed to complete onboarding:', error);
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'Failed to complete onboarding'
-    };
-  }
-}
-
 /**
- * OPTIMIZED: Complete onboarding in a single batched operation
+ * Complete onboarding in one batched operation. This is the only
+ * `complete*` entry point — a legacy `completeOnboarding()` that fanned
+ * out sequential `saveUserPreferences()` + `addTickerSubscription()` x N
+ * + final DB write was deleted in PR #690 because nothing called it any
+ * more and its body still referenced an unimported `sendWelcomeEmail()`
+ * (silently broken at type-check time on `main`).
  *
- * This replaces the sequential calls to:
- * - saveUserPreferences()
- * - addTickerSubscription() x N
- * - completeOnboarding()
- *
- * With a single server action that:
- * 1. Gets auth once
- * 2. Batches all DB operations
- * 3. Updates Clerk metadata once
- * 4. Queues welcome email async (doesn't block)
+ * The batched flow:
+ * 1. Get auth once
+ * 2. Batch all DB operations
+ * 3. Update Clerk metadata once
+ * 4. Queue welcome email async (doesn't block)
  */
 // Server-side validation constants
 const MAX_TICKERS_SERVER = 50;


### PR DESCRIPTION
Deletes the dead `completeOnboarding()` Onboarding entry point from `app/(auth)/onboarding/actions.ts`, leaving `completeOnboardingBatched()` as the one path callers take. Also fixes a pre-existing `TS2304` that has been silently broken on `main`.

## Deepening

Onboarding had two entry-point functions exported from the same file:

- `completeOnboarding()` — sequential `saveUserPreferences()` → `addTickerSubscription()` × N → DB write → Clerk metadata → welcome email
- `completeOnboardingBatched(input)` — same end state in one batched call

`grep -rn '\bcompleteOnboarding\b' --include='*.ts' --include='*.tsx'` (excluding `completeOnboardingBatched` and the unrelated `incompleteOnboarding` landing-copy key) returns exactly one match: the function declaration itself.

The dead function body also referenced `sendWelcomeEmail()` without ever importing it. `npx tsc --noEmit` on `main` reports:

```
app/(auth)/onboarding/actions.ts(246,33): error TS2304: Cannot find name 'sendWelcomeEmail'.
```

The error never blocked a build because no caller reached that line, but it sat in the typecheck output as a permanent confuser. Deleting the function removes both the dead code path and the broken reference.

## Leverage and locality

**Leverage**: callers of Onboarding have one entry point to learn, not two. The "which `complete*` do I call?" question disappears.

**Locality**: behavioural changes to onboarding completion (e.g., when Stripe reconciliation should fire, when Clerk metadata gets written) happen in one place. Today a maintainer reading either function had to verify whether the OTHER function was the source of truth. The docstring on the surviving function captures why the legacy version existed and why it's gone, so future readers don't try to "complete the parallel implementation."

## What was deleted

| Element | Status | Reason |
|---------|--------|--------|
| `completeOnboarding()` function (lines 163–286) | deleted | 0 production callers |
| `sendWelcomeEmail()` reference on (former) line 246 | deleted | name was never imported; only reachable via dead code |
| Comment "This replaces the sequential calls to ... `completeOnboarding()`" | rewritten | the legacy function no longer exists, so the comment's frame is gone |

File shrinks 147 LOC. The `auth`, `currentUser`, `clerkClient`, `getPrismaClient`, and preferences imports are all still used by the surviving exports (`saveUserPreferences`, `addTickerSubscription`, `completeOnboardingBatched`).

## Dependency category

**In-process** per `process/Deepening/deepening.md` §1. Pure orchestration code removed; the surviving function depends on Prisma + Clerk + email-queue helpers it already uses.

## Tests deleted / added

- **Deleted**: none.
- **Added**: none.
- **Re-verified**: `__tests__/app/(auth)/onboarding/onboarding-client.test.tsx` — 6/6 passing. That suite only references `completeOnboardingBatched`, never the deleted function.

## ADRs

- No ADR contradicted, no ADR written. The Onboarding flow's CONTEXT.md term is unchanged.

Nightly-deepen routine PR. Draft for human review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNnF4ggk35FjFQ1q7TsUv9)_