### PR TITLE
deepen: ADRs locking in two rejected orbital deletions

### DIFF
--- a/docs/adr/0007-db-deprecated-stubs-stay-until-tests-decoupled.md
+++ b/docs/adr/0007-db-deprecated-stubs-stay-until-tests-decoupled.md
@@ -1,0 +1,137 @@
+# ADR-0007: `lib/db/` deprecated stubs stay until comprehensive-cron-integration.test.ts is decoupled
+
+Date: 2026-06-22
+Status: accepted
+
+## Context
+
+The autonomous architecture review routine considered deleting four
+zero-production-caller modules in `lib/db/` as a dead-orbital cluster
+collapse, mirroring the shape of recent PRs (lib/sec-edgar/ orbital
+PR #707, lib/audit/summary-audit PR #723, lib/middleware/csrf PR #715,
+lib/utils/file-type-detector PR #714, lib/security/error-responses
+PR #716, etc.).
+
+The candidate cluster:
+
+- `lib/db/budget-operations.ts` (90 LOC) — documented as
+  `DEPRECATED`, all exports (`updateUserBudgetWithLock`,
+  `updateMultipleUserBudgets`) are no-op stubs returning fixed
+  success values. The migration that retired the budget system
+  (`docs/plans/2026-01-02-remove-budget-system-add-credit-monitoring.md`)
+  delegated daily credit limits to OpenRouter, leaving these functions
+  as backwards-compat shims.
+- `lib/db/cost-validation.ts` (300 LOC) — exports
+  `validateCostUpdate`, `validateCostBatch`,
+  `DAILY_COST_LIMITS`, etc. Zero production callers. The
+  `DAILY_COST_LIMITS` constant is independently redefined in
+  `lib/cron/types.ts`.
+- `lib/db/async-audit.ts` (384 LOC) — exports
+  `createAsyncAuditLog`, `flushAuditQueue`, `clearAuditQueue`,
+  `getAuditQueueStats`, `shutdownAuditSystem`. Zero production
+  callers.
+- `lib/db/transaction-manager.ts` (587 LOC) — exports
+  `TransactionManager`, `FilingTransactionManager`,
+  `transactionUtils`. Zero production callers (imports `monitoring`,
+  `async-audit`, and `prisma` but nothing outside the cluster imports
+  back).
+
+`lib/db/concurrency.ts` re-exports `updateUserBudgetWithLock` and
+`validateCostUpdate` for backwards compatibility (lines 325, 458 of
+`concurrency.ts`); both re-exports are marked `@deprecated`.
+
+The cluster appears to satisfy the same deletion test as recent
+dead-orbital deletions: imagine deleting the modules, complexity
+vanishes (zero production callers), and the deletion-test signal is
+"yes, concentrates."
+
+## Decision
+
+**Do not delete.** The four orbital modules and the two
+backwards-compatibility re-exports in `lib/db/concurrency.ts` stay in
+their current form.
+
+## Reasons (load-bearing)
+
+### 1. Tests assert on the deprecated stubs' interfaces
+
+Three test files exist purely to test these dead modules:
+
+- `__tests__/transaction-deadlock-fix.test.ts` — exercises
+  `updateUserBudgetWithLock` and `createAsyncAuditLog` directly.
+- `__tests__/security/budget-manipulation.test.ts` — explicitly
+  comments "The budget functions (updateUserBudgetWithLock,
+  validateCostUpdate) are now no-ops" and asserts the no-op
+  contract.
+- `__tests__/deadlock-fix-validation.test.ts` — asserts
+  `createAsyncAuditLog` is defined.
+
+These are not test waste — they pin the no-op contract so a future
+contributor reading the deprecation comment and "fixing" the stubs
+(e.g., re-introducing budget tracking) breaks tests immediately. The
+shape matches CONTEXT.md "Subscription Active" (`isSubscriptionActive`
+predicate stays canonical) and the precedent ADR-0006 keeps for
+`financial-content-gate.ts` (a module is not the wrong shape merely
+because it has one caller).
+
+### 2. `__tests__/cron/comprehensive-cron-integration.test.ts` is
+deeply entangled with the deprecated surface
+
+This single 1500+-line integration test:
+
+- Imports `updateUserBudgetWithLock` from `lib/db/concurrency` (line
+  28) and uses it across 8+ `mockResolvedValue` setup blocks.
+- Has `jest.mock(...)` blocks for `lib/db/cost-validation`,
+  `lib/db/transaction-manager`, and `lib/db/async-audit` (lines
+  145–162) that pin the mock contracts the cron route relied on
+  before the budget-system migration.
+- Asserts on `FilingTransactionManager.processFilingWithTransaction`
+  callback flow at lines 1261, 1396.
+
+The 9 other tests in `__tests__/transaction-safety/` and
+`__tests__/lib/db/` exercise the same surface to varying degrees.
+
+Deleting the four orbital modules cascades into ~150–200 lines of
+test edits across roughly a dozen test files. The leverage of a
+dead-code deletion does not exceed the test-rewrite churn at this
+ratio.
+
+### 3. The deprecation deadline has not arrived
+
+`budget-operations.ts` itself documents the stubs as a transition
+period (`docs/plans/2026-01-02-remove-budget-system-add-credit-monitoring.md`).
+The migration plan retired the production callers; it did not retire
+the stubs. Until either the comprehensive cron integration test is
+rewritten without budget assertions OR the deprecation deadline
+arrives, the stubs earn their keep as a load-bearing test fixture.
+
+## Consequences
+
+- The four orbital modules (`budget-operations.ts`,
+  `cost-validation.ts`, `async-audit.ts`, `transaction-manager.ts`)
+  stay in place with their current `@deprecated` documentation.
+- The backwards-compat re-exports in `lib/db/concurrency.ts`
+  (`updateUserBudgetWithLock`, `validateCostUpdate`) stay in place.
+- Future architecture reviews should not re-suggest this deletion
+  until one of:
+  1. `__tests__/cron/comprehensive-cron-integration.test.ts` is
+     rewritten or split so that its assertions do not flow through
+     the deprecated `lib/db/` surface.
+  2. The three single-purpose tests
+     (`__tests__/transaction-deadlock-fix.test.ts`,
+     `__tests__/security/budget-manipulation.test.ts`,
+     `__tests__/deadlock-fix-validation.test.ts`) are removed
+     deliberately — at which point the deprecation contract no longer
+     has a test anchor and the stubs can follow.
+- When the deletion eventually happens, the four modules go together
+  as one cluster, the two re-exports go with them, and the three
+  single-purpose tests are deleted at the same time. The
+  comprehensive integration test must be touched.
+
+## Cross-reference
+
+- `docs/plans/actioned/2026/1. January/2026-01-02-remove-budget-system-add-credit-monitoring.md`
+  — the original migration that retired the production callers.
+- ADR-0006 (Financial Content Gate stays as its own module) — the
+  precedent for keeping a module alive when its test surface is the
+  load-bearing reason.

--- a/docs/adr/0008-monitoring-orbital-sub-modules-stay-until-test-utils-refactored.md
+++ b/docs/adr/0008-monitoring-orbital-sub-modules-stay-until-test-utils-refactored.md
@@ -1,0 +1,143 @@
+# ADR-0008: `lib/monitoring/` orbital sub-modules stay until test utilities are refactored
+
+Date: 2026-06-22
+Status: accepted
+
+## Context
+
+The autonomous architecture review routine considered deleting four
+sub-modules of `lib/monitoring/` as a dead-orbital cluster collapse:
+
+- `lib/monitoring/sec-api-monitor.ts` (607 LOC) — exports
+  `MonitoredSECEdgarClient`, `monitoredSecClient`, `SecApiMonitor`.
+- `lib/monitoring/pipeline-error-detector.ts` (999 LOC) — exports
+  `PipelineErrorDetector`, `pipelineErrorDetector`,
+  `detectPipelineErrors`, `generatePipelineHealthReport`,
+  `resolvePipelineAlert`.
+- `lib/monitoring/pipeline-health-monitoring-system.ts` (1040 LOC) —
+  exports `PipelineHealthMonitoringSystem`,
+  `pipelineHealthMonitoring`, `recordLockOperation`,
+  `recordParameterValidation`, `recordSecApiOperation`,
+  `recordUserProcessing`, `getCurrentHealthMetrics`,
+  `getDashboardMetrics`, `startPipelineHealthMonitoring`,
+  `stopPipelineHealthMonitoring`.
+- `lib/monitoring/async-alert-queue.ts` (433 LOC) — exports
+  `AsyncAlertQueue` and related.
+- `lib/monitoring/performance-monitor.ts` (372 LOC) — exports
+  `PerformanceMonitor` and related.
+
+None of these modules have direct production callers outside
+`lib/monitoring/` itself. The `lib/monitoring/index.ts` barrel
+re-exports four of them (`export * from
+'./pipeline-health-monitoring-system'`, etc.) but every production
+import from `lib/monitoring` reads only the `monitoring` singleton
+defined inside `index.ts` — none of the re-exported symbols are
+referenced.
+
+The candidate appears to satisfy the same deletion test as recent
+dead-orbital deletions. The surviving production surface would be the
+`monitoring` singleton in `index.ts` and `json-parsing-monitor.ts`
+(imported by `lib/ai/parsers/response-parser.ts`).
+
+**Note on `cron-monitor.ts`**: this sibling is NOT a deletion
+candidate. `app/api/cron/route.ts` reaches it via dynamic import
+(`await import('@/lib/monitoring/cron-monitor')`) and calls
+`CronJobMonitor.create` / `CronJobMonitor.start`. Static grep over
+top-level imports misses dynamic ones — the autonomous review must
+search for both before classifying a module dead.
+
+## Decision
+
+**Do not delete.** The five orbital sub-modules and the `index.ts`
+re-exports of four of them stay in their current form.
+
+## Reasons (load-bearing)
+
+### 1. `__tests__/utils/secure-test-utils.ts` builds shared mock
+factories on top of the orbital interfaces
+
+`secure-test-utils.ts` defines `AsyncAlertQueueMockFactory` and
+`PerformanceMonitorMockFactory` classes whose contracts match the
+exported shapes of `async-alert-queue.ts` and
+`performance-monitor.ts`. These factories are intended to be reused
+across the broader test suite. Deleting the source modules forces a
+rewrite of the factory contracts (or their deletion), and the test
+files transitively importing them must follow.
+
+### 2. Eight tests in `__tests__/lib/monitoring/` test the orbital
+sub-modules directly
+
+- `async-integration.test.ts`
+- `cron-alert-fix.test.ts`
+- `cron-monitor.test.ts` (the kept module — these tests stay)
+- `cron-status-changes.test.ts`
+- `pipeline-error-detector.test.ts`
+- `async-alert-queue-comprehensive.test.ts`
+- `async-alert-queue.test.ts`
+- `alert-creation-core.test.ts`
+
+Of these, `pipeline-error-detector.test.ts`,
+`async-alert-queue-comprehensive.test.ts`, `async-alert-queue.test.ts`,
+and `alert-creation-core.test.ts` would all need deletion alongside
+the source. The cross-cutting tests (`async-integration`,
+`cron-alert-fix`, `cron-status-changes`) sit at the
+multi-orbital-module integration surface and would need rewriting,
+not deletion.
+
+### 3. `__tests__/security/security-fixes.test.ts` imports
+`pipelineErrorDetector` at line 12
+
+This test imports `pipelineErrorDetector` from
+`@/lib/monitoring/pipeline-error-detector` directly. The single
+import is shallow but the test's existence pins the contract; the
+test would need either rewriting against the live `monitoring`
+singleton or deletion.
+
+### 4. Unlike the lib/parsers orbital, the orbital re-exports are
+*currently visible* through the kept barrel
+
+`lib/monitoring/index.ts` does `export *` from four orbital
+sub-modules. Even though no production code consumes those re-exports
+today, a contributor reading `index.ts` sees the orbital exports as
+the module's public surface. Removing them without first updating
+`index.ts` (and the tests that mock the barrel) creates a
+non-obvious diff vs the recent lib/sec-edgar/ deletion which removed
+the barrel itself.
+
+## Consequences
+
+- The five orbital sub-modules stay in place.
+- The `export *` lines in `lib/monitoring/index.ts` for those four
+  re-exported sub-modules stay.
+- `cron-monitor.ts` and `json-parsing-monitor.ts` are not part of
+  this decision — they have live production callers (cron route
+  dynamic import and `response-parser.ts` direct import
+  respectively) and continue as deep modules behind their own
+  interfaces.
+- Future architecture reviews should not re-suggest this deletion
+  until one of:
+  1. `__tests__/utils/secure-test-utils.ts` is refactored so its
+     `AsyncAlertQueueMockFactory` and `PerformanceMonitorMockFactory`
+     contracts no longer reference the orbital surfaces.
+  2. The eight tests in `__tests__/lib/monitoring/` (excluding the
+     `cron-monitor.test.ts` for the kept module and any kept
+     `posthog-bridge.test.ts`) are deleted or rewritten against the
+     `monitoring` singleton's interface.
+  3. `__tests__/security/security-fixes.test.ts` stops importing
+     `pipelineErrorDetector`.
+- When the deletion eventually happens, the four `export *` lines in
+  `index.ts` go with the source modules and the corresponding test
+  files are removed in the same PR.
+
+## Cross-reference
+
+- ADR-0007 (`lib/db/` deprecated stubs stay until tests decoupled) —
+  the parallel decision for the lib/db cluster facing the same
+  test-entanglement obstacle.
+- ADR-0006 (Financial Content Gate stays as its own module) — the
+  precedent for keeping a module alive when its test surface is the
+  load-bearing reason.
+- CONTEXT.md "Resilience" — documents how a prior generation of
+  orbital `lib/resilience/` and `lib/db/` modules was deleted *with*
+  their tests; that precedent applies once the entanglement here is
+  addressed.


### PR DESCRIPTION
## Why this PR exists

The autonomous architecture review's dead-orbital sweep surfaced three candidates this run. Two — `lib/db/` deprecated stubs and `lib/monitoring/` orbital sub-modules — were rejected mid-implementation for load-bearing test-entanglement reasons. Per the routine spec (`process/improve-codebase-architecture.md` §3), rejected candidates with non-ephemeral reasons get an ADR so future runs don't re-litigate.

This PR contains ADR-0007 and ADR-0008 only — no code changes. The companion deletions that *did* land are tracked in two sibling PRs.

## ADR-0007: `lib/db/` deprecated stubs stay until tests decoupled

**Candidate**: delete `lib/db/budget-operations.ts`, `cost-validation.ts`, `async-audit.ts`, `transaction-manager.ts` (~1361 LOC). All four have zero production callers; `budget-operations.ts` is explicitly documented as `DEPRECATED` with no-op return values left in place by the credit-monitor migration (`docs/plans/.../2026-01-02-remove-budget-system-add-credit-monitoring.md`).

**Rejection reason**: three single-purpose tests pin the no-op contract (`__tests__/transaction-deadlock-fix.test.ts`, `__tests__/security/budget-manipulation.test.ts`, `__tests__/deadlock-fix-validation.test.ts`), and the 1500+-line `__tests__/cron/comprehensive-cron-integration.test.ts` is deeply entangled — it imports `updateUserBudgetWithLock` from `lib/db/concurrency` and mocks `cost-validation` / `transaction-manager` / `async-audit` across ~150-200 lines of assertions. Test churn does not exceed the dead-code leverage at this ratio.

**Deletion conditions** (per ADR-0007): the cluster can be deleted once the comprehensive cron integration test is rewritten without budget assertions, OR once the three single-purpose tests are removed deliberately.

## ADR-0008: `lib/monitoring/` orbital sub-modules stay until test utilities refactored

**Candidate**: delete `lib/monitoring/sec-api-monitor.ts`, `pipeline-error-detector.ts`, `pipeline-health-monitoring-system.ts`, `async-alert-queue.ts`, `performance-monitor.ts` (~3450 LOC). None have direct production callers; the `lib/monitoring/index.ts` barrel `export *`s four of them but every production import reads only the `monitoring` singleton.

**Rejection reason**: `__tests__/utils/secure-test-utils.ts` builds shared `AsyncAlertQueueMockFactory` and `PerformanceMonitorMockFactory` factories on top of the orbital interfaces; eight tests in `__tests__/lib/monitoring/` test these modules directly; `__tests__/security/security-fixes.test.ts` imports `pipelineErrorDetector`. The deletion cascades into broad test rewrites.

**Important nuance**: `lib/monitoring/cron-monitor.ts` is NOT part of this candidate — `app/api/cron/route.ts` reaches it via dynamic import (`await import('@/lib/monitoring/cron-monitor')`). Static grep over top-level imports misses dynamic ones; ADR-0008 records this as a discipline note for future routines so the live module isn't accidentally swept up.

**Deletion conditions** (per ADR-0008): the cluster can be deleted once `secure-test-utils.ts` factories no longer reference the orbital surfaces, OR once the eight tests in `__tests__/lib/monitoring/` (excluding `cron-monitor.test.ts` and any kept `posthog-bridge.test.ts`) are deleted or rewritten against the `monitoring` singleton.

## Dependency category

Not applicable — these ADRs document a decision *not* to deepen. The candidates' dependency category would have been **in-process** (per `process/Deepening/deepening.md` §1) if implemented.

## Tests

No tests deleted or added — this PR is documentation only.

## Cross-reference

- ADR-0006 (Financial Content Gate stays as its own module) — the precedent for keeping a module alive when its test surface is the load-bearing reason. ADR-0007 and ADR-0008 invoke the same shape.
- Companion PRs that *did* land: lib/parsers orbital cluster deletion and lib/parsers/js-backup deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWdyQFpQxsZit1RK5iEYUJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWdyQFpQxsZit1RK5iEYUJ)_