### PR TITLE
deepen: remove dead sendWelcomeEmail export from welcome-service

### DIFF
--- a/__tests__/email/reply-to-regression.test.ts
+++ b/__tests__/email/reply-to-regression.test.ts
@@ -8,9 +8,9 @@
  *   1. The config default falls back to 'wilf@tldrsec.app' (not 'no-reply').
  *      Env override (EMAIL_DEFAULT_REPLY_TO) still works for staging.
  *
- *   2. Both welcome-service code paths (queueWelcomeEmail + sendWelcomeEmail)
- *      set replyTo EXPLICITLY on the EmailMessage, so a future config rollback
- *      can't silently re-break replies. Belt-and-braces.
+ *   2. queueWelcomeEmail (the welcome-service code path) sets replyTo
+ *      EXPLICITLY on the EmailMessage, so a future config rollback can't
+ *      silently re-break replies. Belt-and-braces.
  *
  * The source-grep style is intentional: it catches the specific regression
  * pattern (sending without explicit replyTo) without booting prisma/clerk/resend.
@@ -55,22 +55,14 @@ describe('reply-to regression', () => {
 
     // Match either the literal "wilf@tldrsec.app" or the FOUNDER_REPLY_TO constant.
     // The constant lives in lib/email/config.ts; either is acceptable as long as
-    // both code paths set replyTo to something other than no-reply@.
+    // queueWelcomeEmail sets replyTo to something other than no-reply@.
     const REPLY_TO_PATTERN = /replyTo:\s*(FOUNDER_REPLY_TO|['"]wilf@tldrsec\.app['"])/;
 
     it('queueWelcomeEmail sets an explicit replyTo on the EmailMessage', () => {
       const queueFnIdx = source.indexOf('export async function queueWelcomeEmail');
       expect(queueFnIdx).toBeGreaterThan(-1);
-      const exportIdx = source.indexOf('export async function sendWelcomeEmail');
-      const queueBody = source.slice(queueFnIdx, exportIdx > 0 ? exportIdx : undefined);
+      const queueBody = source.slice(queueFnIdx);
       expect(queueBody).toMatch(REPLY_TO_PATTERN);
-    });
-
-    it('sendWelcomeEmail sets an explicit replyTo on the EmailMessage', () => {
-      const sendFnIdx = source.indexOf('export async function sendWelcomeEmail');
-      expect(sendFnIdx).toBeGreaterThan(-1);
-      const sendBody = source.slice(sendFnIdx);
-      expect(sendBody).toMatch(REPLY_TO_PATTERN);
     });
 
     it('contains no remaining no-reply@ literal in welcome-service', () => {

--- a/lib/email/welcome-service.ts
+++ b/lib/email/welcome-service.ts
@@ -1,6 +1,5 @@
 'use server';
 
-import { auth, currentUser, clerkClient } from '@clerk/nextjs/server';
 import { getPrismaClient } from '@/lib/db/prisma';
 import { getEmailTemplate } from './templates';
 import { EmailType, EmailMessage } from './types';
@@ -9,12 +8,11 @@ import { FOUNDER_REPLY_TO } from './config';
 import { logger } from '../logging';
 import { SecureEmailLogger } from './security-helpers';
 
-// Create secure logger to prevent PII exposure
 const secureLogger = new SecureEmailLogger(logger.child('welcome-service'));
 
 /**
- * Queue a welcome email to be sent asynchronously (fire-and-forget)
- * This version takes pre-fetched user data to avoid redundant auth/DB calls
+ * Queue a welcome email to be sent asynchronously (fire-and-forget).
+ * Takes pre-fetched user data so callers avoid redundant auth/DB calls.
  *
  * @param userId - Database user ID (not Clerk ID)
  * @param email - User's email address
@@ -91,132 +89,3 @@ export async function queueWelcomeEmail(
     }
   });
 }
-
-/**
- * Send welcome email to a user who completed onboarding
- * 
- * @returns Success status and any error information
- */
-export async function sendWelcomeEmail(): Promise<{ success: boolean; error?: string }> {
-  try {
-    const { userId } = await auth();
-    
-    if (!userId) {
-      return { success: false, error: 'User not authenticated' };
-    }
-    
-    // Get user details from Clerk
-    const user = await currentUser();
-    if (!user) {
-      return { success: false, error: 'User not found' };
-    }
-    
-    // Get primary email
-    const primaryEmail = user.emailAddresses[0]?.emailAddress;
-    if (!primaryEmail) {
-      return { success: false, error: 'No primary email found' };
-    }
-    
-    // Get user from database
-    const dbUser = await getPrismaClient().user.findFirst({
-      where: { 
-        authProviderId: userId 
-      },
-      include: {
-        tickers: true
-      }
-    });
-    
-    if (!dbUser) {
-      return { success: false, error: 'User not found in database' };
-    }
-    
-    // Get user's tracked tickers
-    const selectedTickers = dbUser.tickers.map(ticker => ticker.symbol);
-    
-    // Generate welcome email content
-    const { html, text } = await getEmailTemplate(EmailType.WELCOME, {
-      recipientName: dbUser.name || user.firstName || 'there',
-      recipientEmail: primaryEmail,
-      selectedTickers,
-      unsubscribeUrl: `${process.env.NEXT_PUBLIC_APP_URL || 'https://tldrsec.app'}/dashboard/settings`,
-      preferencesUrl: `${process.env.NEXT_PUBLIC_APP_URL}/settings`
-    });
-    
-    // Prepare email message. Explicit replyTo for the same reason as
-    // queueWelcomeEmail above.
-    const message: EmailMessage = {
-      to: primaryEmail,
-      subject: 'Welcome to tldrSEC!',
-      replyTo: FOUNDER_REPLY_TO,
-      html,
-      text,
-      tags: [
-        'type:welcome',
-        'onboarding:complete'
-      ],
-      metadata: {
-        userId: dbUser.id,
-        type: 'welcome',
-        tickerCount: selectedTickers.length,
-        summaryCount: 0  // No summaries for welcome email
-      }
-    };
-    
-    // Update user's onboarding status - do this first to ensure it happens even if email fails
-    await getPrismaClient().user.update({
-      where: { id: dbUser.id },
-      data: {
-        onboardingCompleted: true
-      }
-    });
-
-    // Sync onboarding status to Clerk publicMetadata for client-side access
-    try {
-      const client = await clerkClient();
-      await client.users.updateUserMetadata(userId, {
-        publicMetadata: { onboardingCompleted: true }
-      });
-      secureLogger.info('Synced onboardingCompleted to Clerk publicMetadata', { userId });
-    } catch (metadataError) {
-      secureLogger.error('Failed to sync publicMetadata to Clerk', {
-        error: metadataError instanceof Error ? metadataError.message : 'Unknown error',
-        userId
-      });
-      // Non-critical - user can still use the app
-    }
-    
-    // Try to send email, but don't fail the whole function if this part errors
-    try {
-      // Send email
-      const result = await sendEmail(message);
-      
-      if (!result.success) {
-        logger.warn(`Email sending returned failure: ${result.error?.message}`, {
-          userId: dbUser.id
-        });
-      } else {
-        // Log success
-        secureLogger.info('Sent welcome email', {
-          to: primaryEmail,
-          userId: dbUser.id,
-          emailId: result.id
-        });
-      }
-    } catch (emailError) {
-      // Log the error but continue - user has been marked as onboarded
-      secureLogger.error('Failed to send welcome email but continuing', {
-        error: emailError instanceof Error ? emailError.message : 'Unknown error',
-        userId: dbUser.id
-      });
-    }
-    
-    return { success: true };
-  } catch (error) {
-    console.error('Failed to send welcome email:', error);
-    return { 
-      success: false, 
-      error: error instanceof Error ? error.message : 'Failed to send welcome email' 
-    };
-  }
-} 


### PR DESCRIPTION
## Deepening

Replaces a two-function welcome-email surface with the single function production actually uses.

`lib/email/welcome-service.ts` exported two ways to send the onboarding welcome email:

- `queueWelcomeEmail(userId, email, name)` — the fire-and-forget background queue path that takes pre-fetched user data.
- `sendWelcomeEmail()` — a self-contained variant that called `auth()` / `currentUser()` / `clerkClient()` and did its own DB fetch.

`queueWelcomeEmail` is the production path: imported by `app/(auth)/onboarding/actions.ts` at the single welcome-email send site. `sendWelcomeEmail` has zero production callers — every other repo reference to the name is either an unrelated `components/onboarding/send-welcome-email.ts` (a different function that POSTs to an API endpoint) or `app/api/waitlist/route.ts` (a local file-scoped helper defined at line 168 of that file). Neither imports from `lib/email/welcome-service`.

The dead function was 122 LOC carrying its own auth path, its own DB fetch path, its own Clerk `publicMetadata` sync, and its own try/catch shape — duplicated infrastructure for an entry point production deliberately moved away from when it adopted the background queue.

## Leverage and locality

**Leverage at the interface.** `lib/email/welcome-service` now exposes one function instead of two. Callers reading the module see exactly what production sends.

**Locality for maintainers.** No more "which welcome path do I touch?" decision on every welcome-email change. The auth-and-fetch shape, the Clerk sync, the explicit `replyTo` setup — all live in one place rather than diverging across two near-twins.

## Dependency category and adapter strategy

**True external (Resend, Clerk, Prisma).** No interface change for the survivor — the existing in-memory mock pattern in the regression test continues to cover both `getEmailTemplate` and `sendEmail` collaborators of `queueWelcomeEmail`.

## Tests deleted

- The `sendWelcomeEmail sets an explicit replyTo on the EmailMessage` block in `__tests__/email/reply-to-regression.test.ts` is removed alongside the function.

## Tests added

None at the new interface. The reply-to regression test still locks in the `no-reply@tldrsec.app` regression by asserting on `queueWelcomeEmail` and on the `lib/email/config.ts` default. Test docstring updated to describe one path instead of two.

## ADRs

Respects ADR-0001 through ADR-0006 (none touch this file). No new ADR — the deletion is well-explained by the PR body.

## Stats

2 files changed · 7 insertions · 146 deletions.

---
_Generated by [Claude Code](https://claude.ai/code/session_013AwcFRusVY8F8BLDLt6cUZ)_