### PR TITLE
deepen: slim PaymentLogger to its used interface

### DIFF
--- a/lib/audit/payment-logger.ts
+++ b/lib/audit/payment-logger.ts
@@ -1,49 +1,59 @@
+/**
+ * Payment Audit Logger.
+ *
+ * Deep module behind two helpers — `PaymentLogger.checkoutStarted` and
+ * `PaymentLogger.checkoutFailed` — that the checkout API
+ * (`app/api/checkout/route.ts`) calls to persist Stripe Checkout
+ * lifecycle events to the `SecurityAuditLog` table. The helpers carry
+ * the per-event-type shape (severity, source, metadata layout) so
+ * callers never assemble those fields by hand.
+ *
+ * Previously the same namespace exported six additional helpers —
+ * `checkoutCompleted`, `webhookReceived`, `subscriptionUpdated`,
+ * `rateLimitExceeded` — plus six unused `PaymentEventType` enum entries
+ * (`CHECKOUT_COMPLETED`, `SUBSCRIPTION_CREATED`, `SUBSCRIPTION_UPDATED`,
+ * `SUBSCRIPTION_CANCELLED`, `PAYMENT_SUCCEEDED`, `PAYMENT_FAILED`,
+ * `WEBHOOK_RECEIVED`, `RATE_LIMIT_EXCEEDED`). None had a production
+ * caller; they were a speculative "common events" catalogue. Stripe
+ * webhook handlers and rate-limit middleware in this repo do not funnel
+ * through this module. Removing them concentrates the seam on the
+ * checkout-lifecycle events the system actually ships.
+ *
+ * Per LANGUAGE.md "one adapter = hypothetical seam": each removed
+ * helper had zero adapters. The remaining surface is the real seam.
+ */
+
 import { getPrismaClient } from '@/lib/db/prisma';
 
 export enum PaymentEventType {
   CHECKOUT_STARTED = 'checkout_started',
-  CHECKOUT_COMPLETED = 'checkout_completed', 
   CHECKOUT_FAILED = 'checkout_failed',
-  SUBSCRIPTION_CREATED = 'subscription_created',
-  SUBSCRIPTION_UPDATED = 'subscription_updated',
-  SUBSCRIPTION_CANCELLED = 'subscription_cancelled',
-  PAYMENT_SUCCEEDED = 'payment_succeeded',
-  PAYMENT_FAILED = 'payment_failed',
-  WEBHOOK_RECEIVED = 'webhook_received',
-  RATE_LIMIT_EXCEEDED = 'rate_limit_exceeded',
 }
 
-export interface PaymentEvent {
+interface PaymentEvent {
   type: PaymentEventType;
   userId?: string;
   email?: string;
   amount?: number;
   currency?: string;
-  stripeEventId?: string;
-  subscriptionId?: string;
-  customerId?: string;
   metadata?: Record<string, unknown>;
   ipAddress?: string;
   userAgent?: string;
   error?: string;
 }
 
-export async function logPaymentEvent(event: PaymentEvent): Promise<void> {
+async function logPaymentEvent(event: PaymentEvent): Promise<void> {
   const prisma = getPrismaClient();
-  
+
   try {
-    // Log to console for immediate monitoring
     console.log(`[Payment Audit] ${event.type}`, {
       timestamp: new Date().toISOString(),
       userId: event.userId,
       email: event.email,
       amount: event.amount,
-      stripeEventId: event.stripeEventId,
-      subscriptionId: event.subscriptionId,
       error: event.error,
     });
-    
-    // Store in database for audit trail
+
     await prisma.securityAuditLog.create({
       data: {
         eventType: event.type,
@@ -52,9 +62,6 @@ export async function logPaymentEvent(event: PaymentEvent): Promise<void> {
           email: event.email,
           amount: event.amount,
           currency: event.currency,
-          stripeEventId: event.stripeEventId,
-          subscriptionId: event.subscriptionId,
-          customerId: event.customerId,
           metadata: event.metadata,
           ipAddress: event.ipAddress,
           userAgent: event.userAgent,
@@ -66,14 +73,19 @@ export async function logPaymentEvent(event: PaymentEvent): Promise<void> {
       },
     });
   } catch (error) {
-    // Don't let audit logging failures break the main flow
+    // Audit logging failures must never break the checkout flow.
     console.error('[Payment Audit] Failed to log event:', error);
   }
 }
 
-// Helper functions for common events
 export const PaymentLogger = {
-  async checkoutStarted(data: { email: string; planType: string; amount?: number; ipAddress?: string; userAgent?: string }) {
+  async checkoutStarted(data: {
+    email: string;
+    planType: string;
+    amount?: number;
+    ipAddress?: string;
+    userAgent?: string;
+  }) {
     await logPaymentEvent({
       type: PaymentEventType.CHECKOUT_STARTED,
       email: data.email,
@@ -85,54 +97,18 @@ export const PaymentLogger = {
     });
   },
 
-  async checkoutCompleted(data: { userId?: string; email: string; amount: number; subscriptionId?: string; customerId?: string }) {
-    await logPaymentEvent({
-      type: PaymentEventType.CHECKOUT_COMPLETED,
-      userId: data.userId,
-      email: data.email,
-      amount: data.amount,
-      currency: 'USD',
-      subscriptionId: data.subscriptionId,
-      customerId: data.customerId,
-    });
-  },
-
-  async checkoutFailed(data: { email: string; error: string; amount?: number; ipAddress?: string }) {
+  async checkoutFailed(data: {
+    email: string;
+    error: string;
+    amount?: number;
+    ipAddress?: string;
+  }) {
     await logPaymentEvent({
       type: PaymentEventType.CHECKOUT_FAILED,
       email: data.email,
       amount: data.amount,
       error: data.error,
       ipAddress: data.ipAddress,
-    });
-  },
-
-  async webhookReceived(data: { stripeEventId: string; type: string; customerId?: string; subscriptionId?: string }) {
-    await logPaymentEvent({
-      type: PaymentEventType.WEBHOOK_RECEIVED,
-      stripeEventId: data.stripeEventId,
-      customerId: data.customerId,
-      subscriptionId: data.subscriptionId,
-      metadata: { webhookType: data.type },
-    });
-  },
-
-  async subscriptionUpdated(data: { userId: string; subscriptionId: string; oldTier?: string; newTier: string }) {
-    await logPaymentEvent({
-      type: PaymentEventType.SUBSCRIPTION_UPDATED,
-      userId: data.userId,
-      subscriptionId: data.subscriptionId,
-      metadata: { oldTier: data.oldTier, newTier: data.newTier },
-    });
-  },
-
-  async rateLimitExceeded(data: { ipAddress: string; endpoint: string; userAgent?: string }) {
-    await logPaymentEvent({
-      type: PaymentEventType.RATE_LIMIT_EXCEEDED,
-      ipAddress: data.ipAddress,
-      userAgent: data.userAgent,
-      metadata: { endpoint: data.endpoint },
-      error: 'Rate limit exceeded',
     });
   },
 };


### PR DESCRIPTION
## Deepening

Replaces a six-helper namespace (four of which had zero adapters) with a two-helper namespace that names exactly the audit events the checkout pipeline ships.

`lib/audit/payment-logger.ts` previously exported:
- `PaymentLogger.checkoutStarted` ← **used** by `app/api/checkout/route.ts:34`
- `PaymentLogger.checkoutFailed` ← **used** by `app/api/checkout/route.ts:90,137`
- `PaymentLogger.checkoutCompleted` ← zero adapters
- `PaymentLogger.webhookReceived` ← zero adapters
- `PaymentLogger.subscriptionUpdated` ← zero adapters
- `PaymentLogger.rateLimitExceeded` ← zero adapters

Plus six `PaymentEventType` enum entries (`CHECKOUT_COMPLETED`, `SUBSCRIPTION_CREATED`, `SUBSCRIPTION_UPDATED`, `SUBSCRIPTION_CANCELLED`, `PAYMENT_SUCCEEDED`, `PAYMENT_FAILED`, `WEBHOOK_RECEIVED`, `RATE_LIMIT_EXCEEDED`) that referenced no code path the system actually exercises, and the `PaymentEvent` fields the dead helpers needed (`stripeEventId`, `subscriptionId`, `customerId`). Stripe webhook handlers, rate-limit middleware, and subscription-lifecycle reconcilers in this repo do NOT funnel through this module — the dead helpers were a speculative "common events" catalogue.

## Leverage and locality

- **Leverage** for callers: unchanged at the live surface. The two helpers actually invoked still wrap the `securityAuditLog.create` shape (severity, source, eventType, metadata layout) so the checkout route never hand-assembles those fields. A future contributor who wires a Stripe webhook handler will add a new helper deliberately rather than discover four near-empty ones already there.
- **Locality** for maintainers: a maintainer searching for "where checkout audit logs are written" now lands on one short module that names exactly the events the system ships. The 6 dead enum entries that previously suggested a wider audit surface — and the helpers that suggested existing webhook integration — no longer mislead.

## Dependency category and adapter strategy

Per `process/Deepening/deepening.md` — **Local-substitutable** (Postgres via Prisma). No port; no adapter. The seam stays at the same place (the two `PaymentLogger.checkoutXxx` helpers); this PR only removes the four sibling helpers that crossed no seam.

## Tests deleted and tests added

- Deleted: 0. The module had zero test files. `__tests__/` had no references to `PaymentLogger`, `PaymentEventType`, or `payment-logger` before this change — the deleted helpers were never exercised in test either.
- Added: 0. The live surface is exercised through the checkout flow's integration tests (`__tests__/integration/payment-flow-e2e.test.ts`, `__tests__/integration/checkout-flow.test.ts` — both pass before and after this change).

Baseline before this change: `--testPathPattern='audit|payment'` 55 passed, 0 failed. After: 55 passed, 0 failed. `--testPathPattern='checkout'` shows 1 pre-existing env-var failure (`STRIPE_PRICE_ID` missing in test env) and 10 passing both before and after.

## ADRs respected

- ADR-0004 (Lifetime Seat) — unaffected. The Lifetime Seat checkout flow uses the same `PaymentLogger.checkoutStarted` / `.checkoutFailed` pair; the slim does not touch it.
- No ADR governs this module.

CONTEXT.md doesn't name `PaymentLogger` as a domain term — it's plumbing, not a project-vocabulary concept. No CONTEXT.md update required.

Matches the pattern of recent slim-to-used-interface deepenings: #695 (openrouter-credit-monitor), #688 (environment-aware-fetcher), #689 (CronSecFilingService).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZo6i9t2Ytg4KCGoCY3aZy

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZo6i9t2Ytg4KCGoCY3aZy)_