### PR TITLE
deepen: RecoveryStateService mutations return fresh state

### DIFF
--- a/__tests__/cron/comprehensive-auto-recover.test.ts
+++ b/__tests__/cron/comprehensive-auto-recover.test.ts
@@ -128,24 +128,27 @@ jest.mock('@/lib/cron/orphaned-filing-detector', () => ({
   },
 }));
 
-jest.mock('@/lib/cron/recovery-state-service', () => ({
-  RecoveryStateService: {
-    getState: jest.fn().mockResolvedValue({
-      consecutiveDegraded: 0,
-      consecutiveCleanups: 0,
-      consecutiveRedeploys: 0,
-      lastCleanupTime: null,
-      lastRedeployTime: null,
-      lastHealthyTime: null,
-      lastDegradedTime: null,
-    }),
-    incrementConsecutiveDegraded: jest.fn().mockResolvedValue(undefined),
-    resetOnHealthy: jest.fn().mockResolvedValue(undefined),
-    recordCleanup: jest.fn().mockResolvedValue(undefined),
-    clearCache: jest.fn(),
-    reset: jest.fn().mockResolvedValue(undefined),
-  },
-}));
+jest.mock('@/lib/cron/recovery-state-service', () => {
+  const defaultState = {
+    consecutiveDegraded: 0,
+    consecutiveCleanups: 0,
+    consecutiveRedeploys: 0,
+    lastCleanupTime: null,
+    lastRedeployTime: null,
+    lastHealthyTime: null,
+    lastDegradedTime: null,
+  };
+  return {
+    RecoveryStateService: {
+      getState: jest.fn().mockResolvedValue({ ...defaultState }),
+      incrementConsecutiveDegraded: jest.fn().mockResolvedValue({ ...defaultState }),
+      resetOnHealthy: jest.fn().mockResolvedValue({ ...defaultState }),
+      recordCleanup: jest.fn().mockResolvedValue({ ...defaultState }),
+      recordRedeploy: jest.fn().mockResolvedValue({ ...defaultState }),
+      reset: jest.fn().mockResolvedValue({ ...defaultState }),
+    },
+  };
+});
 
 // Import after mocks
 import { GET } from '@/app/api/cron/route';
@@ -160,7 +163,6 @@ const mockGetState = RecoveryStateService.getState as jest.MockedFunction<typeof
 const mockIncrementConsecutiveDegraded = RecoveryStateService.incrementConsecutiveDegraded as jest.MockedFunction<typeof RecoveryStateService.incrementConsecutiveDegraded>;
 const mockResetOnHealthy = RecoveryStateService.resetOnHealthy as jest.MockedFunction<typeof RecoveryStateService.resetOnHealthy>;
 const mockRecordCleanup = RecoveryStateService.recordCleanup as jest.MockedFunction<typeof RecoveryStateService.recordCleanup>;
-const mockClearCache = RecoveryStateService.clearCache as jest.MockedFunction<typeof RecoveryStateService.clearCache>;
 const mockResetState = RecoveryStateService.reset as jest.MockedFunction<typeof RecoveryStateService.reset>;
 
 function createMockRequest(url = 'http://localhost:3000/api/cron?action=auto-recover'): NextRequest {
@@ -238,24 +240,24 @@ describe('Comprehensive Auto-Recovery - Phase 6', () => {
       lastDegradedTime: null,
     };
 
-    // Configure recovery state service mocks
+    // Configure recovery state service mocks — mutations return the fresh state
+    // so callers never chain `await mutate(); await getState()`.
     mockGetState.mockImplementation(() => Promise.resolve({ ...mockRecoveryStateData }));
     mockIncrementConsecutiveDegraded.mockImplementation(() => {
       mockRecoveryStateData.consecutiveDegraded++;
       mockRecoveryStateData.lastDegradedTime = new Date();
-      return Promise.resolve();
+      return Promise.resolve({ ...mockRecoveryStateData });
     });
     mockResetOnHealthy.mockImplementation(() => {
       mockRecoveryStateData.consecutiveDegraded = 0;
       mockRecoveryStateData.lastHealthyTime = new Date();
-      return Promise.resolve();
+      return Promise.resolve({ ...mockRecoveryStateData });
     });
     mockRecordCleanup.mockImplementation(() => {
       mockRecoveryStateData.consecutiveCleanups++;
       mockRecoveryStateData.lastCleanupTime = new Date();
-      return Promise.resolve();
+      return Promise.resolve({ ...mockRecoveryStateData });
     });
-    mockClearCache.mockImplementation(() => Promise.resolve());
     mockResetState.mockImplementation(() => {
       mockRecoveryStateData = {
         consecutiveDegraded: 0,
@@ -266,7 +268,7 @@ describe('Comprehensive Auto-Recovery - Phase 6', () => {
         lastHealthyTime: null,
         lastDegradedTime: null,
       };
-      return Promise.resolve();
+      return Promise.resolve({ ...mockRecoveryStateData });
     });
 
     // Reset detectors to no issues found
@@ -401,11 +403,10 @@ describe('Comprehensive Auto-Recovery - Phase 6', () => {
     });
 
     it('should maintain state across simulated deploys', async () => {
-      // First call - simulate DEGRADED state that's been accumulating
+      // First call - simulate DEGRADED state that's been accumulating.
+      // A deploy is transparent to the caller — the module always reads from
+      // the persisted RecoveryState row, so we just seed the shared mock.
       mockRecoveryStateData.consecutiveDegraded = 2;
-
-      // Simulate deploy by clearing cache
-      mockClearCache();
 
       // Override fetch to return DEGRADED status so the state is maintained (not reset)
       mockFetch.mockImplementation((url: string) => {

--- a/__tests__/cron/persistent-recovery-state.test.ts
+++ b/__tests__/cron/persistent-recovery-state.test.ts
@@ -1,34 +1,76 @@
 /**
- * Tests for RecoveryStateService
+ * Tests for RecoveryStateService — the deep persistent-recovery module.
  *
- * Unit tests for RecoveryStateService that verify the service correctly
- * interacts with the database to persist recovery state.
+ * These tests assert on observable outcomes through the module's
+ * interface: after a mutation, the returned RecoveryState reflects the
+ * new counters and timestamps. The pre-deepening suite asserted on the
+ * shape of Prisma `upsert` calls (past the interface) and on the
+ * behaviour of an in-memory cache that no longer exists.
  *
  * @see docs/plans/2026-01-09-eliminate-manual-pipeline-intervention.md Phase 1
  */
 
 import { getPrismaClient } from '@/lib/db/prisma';
-import { RecoveryStateService } from '@/lib/cron/recovery-state-service';
+import {
+  RecoveryStateService,
+  type RecoveryState,
+} from '@/lib/cron/recovery-state-service';
 
-// Get mocked Prisma client
 const mockPrisma = getPrismaClient();
+
+interface RecoveryRow {
+  id: string;
+  consecutiveDegraded: number;
+  consecutiveCleanups: number;
+  consecutiveRedeploys: number;
+  lastCleanupTime: Date | null;
+  lastRedeployTime: Date | null;
+  lastHealthyTime: Date | null;
+  lastDegradedTime: Date | null;
+}
+
+const emptyRow: RecoveryRow = {
+  id: 'singleton',
+  consecutiveDegraded: 0,
+  consecutiveCleanups: 0,
+  consecutiveRedeploys: 0,
+  lastCleanupTime: null,
+  lastRedeployTime: null,
+  lastHealthyTime: null,
+  lastDegradedTime: null,
+};
+
+function mockUpsertReturns(row: Partial<RecoveryRow>): void {
+  (mockPrisma.recoveryState.upsert as jest.Mock).mockResolvedValueOnce({
+    ...emptyRow,
+    ...row,
+  });
+}
+
+function mockFindUniqueReturns(row: Partial<RecoveryRow> | null): void {
+  if (row === null) {
+    (mockPrisma.recoveryState.findUnique as jest.Mock).mockResolvedValueOnce(null);
+  } else {
+    (mockPrisma.recoveryState.findUnique as jest.Mock).mockResolvedValueOnce({
+      ...emptyRow,
+      ...row,
+    });
+  }
+}
 
 describe('RecoveryStateService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    RecoveryStateService.clearCache();
   });
 
   describe('getState', () => {
-    it('should return default state when no state exists in database', async () => {
-      // Mock findUnique to return null (no existing state)
-      (mockPrisma.recoveryState.findUnique as jest.Mock).mockResolvedValueOnce(null);
-      // Mock create for initial state
-      (mockPrisma.recoveryState.create as jest.Mock).mockResolvedValueOnce({ id: 'singleton' });
+    it('creates and returns the default state when no row exists', async () => {
+      mockFindUniqueReturns(null);
+      (mockPrisma.recoveryState.create as jest.Mock).mockResolvedValueOnce(emptyRow);
 
       const state = await RecoveryStateService.getState();
 
-      expect(state).toEqual({
+      expect(state).toEqual<RecoveryState>({
         consecutiveDegraded: 0,
         consecutiveCleanups: 0,
         consecutiveRedeploys: 0,
@@ -37,14 +79,10 @@ describe('RecoveryStateService', () => {
         lastHealthyTime: null,
         lastDegradedTime: null,
       });
-      expect(mockPrisma.recoveryState.findUnique).toHaveBeenCalledWith({
-        where: { id: 'singleton' },
-      });
     });
 
-    it('should return persisted state from database', async () => {
-      const mockDbState = {
-        id: 'singleton',
+    it('returns the persisted state when a row exists', async () => {
+      const persisted = {
         consecutiveDegraded: 2,
         consecutiveCleanups: 1,
         consecutiveRedeploys: 0,
@@ -53,136 +91,124 @@ describe('RecoveryStateService', () => {
         lastHealthyTime: new Date('2026-01-09T09:00:00Z'),
         lastDegradedTime: new Date('2026-01-09T10:30:00Z'),
       };
-      (mockPrisma.recoveryState.findUnique as jest.Mock).mockResolvedValueOnce(mockDbState);
+      mockFindUniqueReturns(persisted);
 
       const state = await RecoveryStateService.getState();
 
       expect(state.consecutiveDegraded).toBe(2);
       expect(state.consecutiveCleanups).toBe(1);
       expect(state.lastCleanupTime).toEqual(new Date('2026-01-09T10:00:00Z'));
+      expect(state.lastHealthyTime).toEqual(new Date('2026-01-09T09:00:00Z'));
     });
   });
 
   describe('incrementConsecutiveDegraded', () => {
-    it('should call upsert with increment operation', async () => {
-      (mockPrisma.recoveryState.upsert as jest.Mock).mockResolvedValueOnce({ id: 'singleton' });
+    it('returns the fresh state with the incremented degraded counter', async () => {
+      const nowIsh = new Date('2026-01-09T11:00:00Z');
+      mockUpsertReturns({
+        consecutiveDegraded: 3,
+        lastDegradedTime: nowIsh,
+      });
 
-      await RecoveryStateService.incrementConsecutiveDegraded();
+      const state = await RecoveryStateService.incrementConsecutiveDegraded();
 
-      expect(mockPrisma.recoveryState.upsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { id: 'singleton' },
-          create: expect.objectContaining({
-            id: 'singleton',
-            consecutiveDegraded: 1,
-          }),
-          update: expect.objectContaining({
-            consecutiveDegraded: { increment: 1 },
-          }),
-        })
-      );
+      expect(state.consecutiveDegraded).toBe(3);
+      expect(state.lastDegradedTime).toEqual(nowIsh);
     });
   });
 
   describe('recordCleanup', () => {
-    it('should call upsert with cleanup increment', async () => {
-      (mockPrisma.recoveryState.upsert as jest.Mock).mockResolvedValueOnce({ id: 'singleton' });
+    it('returns the fresh state with the incremented cleanup counter', async () => {
+      const cleanupTime = new Date('2026-01-09T11:05:00Z');
+      mockUpsertReturns({
+        consecutiveCleanups: 4,
+        lastCleanupTime: cleanupTime,
+      });
 
-      await RecoveryStateService.recordCleanup();
+      const state = await RecoveryStateService.recordCleanup();
 
-      expect(mockPrisma.recoveryState.upsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { id: 'singleton' },
-          update: expect.objectContaining({
-            consecutiveCleanups: { increment: 1 },
-          }),
-        })
-      );
+      expect(state.consecutiveCleanups).toBe(4);
+      expect(state.lastCleanupTime).toEqual(cleanupTime);
     });
   });
 
   describe('recordRedeploy', () => {
-    it('should call upsert with redeploy increment', async () => {
-      (mockPrisma.recoveryState.upsert as jest.Mock).mockResolvedValueOnce({ id: 'singleton' });
+    it('returns the fresh state with the incremented redeploy counter', async () => {
+      const redeployTime = new Date('2026-01-09T11:10:00Z');
+      mockUpsertReturns({
+        consecutiveRedeploys: 2,
+        lastRedeployTime: redeployTime,
+      });
 
-      await RecoveryStateService.recordRedeploy();
+      const state = await RecoveryStateService.recordRedeploy();
 
-      expect(mockPrisma.recoveryState.upsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { id: 'singleton' },
-          update: expect.objectContaining({
-            consecutiveRedeploys: { increment: 1 },
-          }),
-        })
-      );
+      expect(state.consecutiveRedeploys).toBe(2);
+      expect(state.lastRedeployTime).toEqual(redeployTime);
     });
   });
 
   describe('resetOnHealthy', () => {
-    it('should reset degraded counter to zero', async () => {
-      (mockPrisma.recoveryState.upsert as jest.Mock).mockResolvedValueOnce({ id: 'singleton' });
+    it('returns the fresh state with degraded counter cleared and healthy timestamp set', async () => {
+      const healthyTime = new Date('2026-01-09T11:15:00Z');
+      mockUpsertReturns({
+        consecutiveDegraded: 0,
+        consecutiveCleanups: 5,
+        consecutiveRedeploys: 1,
+        lastHealthyTime: healthyTime,
+      });
 
-      await RecoveryStateService.resetOnHealthy();
+      const state = await RecoveryStateService.resetOnHealthy();
 
-      expect(mockPrisma.recoveryState.upsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { id: 'singleton' },
-          update: expect.objectContaining({
-            consecutiveDegraded: 0,
-          }),
-        })
-      );
+      expect(state.consecutiveDegraded).toBe(0);
+      expect(state.consecutiveCleanups).toBe(5);
+      expect(state.consecutiveRedeploys).toBe(1);
+      expect(state.lastHealthyTime).toEqual(healthyTime);
     });
   });
 
   describe('reset', () => {
-    it('should reset all counters to default values', async () => {
-      (mockPrisma.recoveryState.upsert as jest.Mock).mockResolvedValueOnce({ id: 'singleton' });
+    it('returns the fully-defaulted state', async () => {
+      mockUpsertReturns(emptyRow);
 
-      await RecoveryStateService.reset();
+      const state = await RecoveryStateService.reset();
 
-      expect(mockPrisma.recoveryState.upsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { id: 'singleton' },
-          update: expect.objectContaining({
-            consecutiveDegraded: 0,
-            consecutiveCleanups: 0,
-            consecutiveRedeploys: 0,
-            lastCleanupTime: null,
-            lastRedeployTime: null,
-            lastHealthyTime: null,
-            lastDegradedTime: null,
-          }),
-        })
-      );
-    });
-  });
-
-  describe('clearCache', () => {
-    it('should clear the in-memory cache', async () => {
-      // First load state into cache
-      const mockDbState = {
-        id: 'singleton',
-        consecutiveDegraded: 5,
+      expect(state).toEqual<RecoveryState>({
+        consecutiveDegraded: 0,
         consecutiveCleanups: 0,
         consecutiveRedeploys: 0,
         lastCleanupTime: null,
         lastRedeployTime: null,
         lastHealthyTime: null,
         lastDegradedTime: null,
-      };
-      (mockPrisma.recoveryState.findUnique as jest.Mock).mockResolvedValue(mockDbState);
+      });
+    });
+  });
 
-      await RecoveryStateService.getState();
+  describe('mutation-then-caller pattern', () => {
+    it('lets a caller drive a full cleanup+healthy sequence without a follow-up getState', async () => {
+      const cleanupTime = new Date('2026-01-09T12:00:00Z');
+      mockUpsertReturns({
+        consecutiveCleanups: 1,
+        lastCleanupTime: cleanupTime,
+      });
+      const healthyTime = new Date('2026-01-09T12:05:00Z');
+      mockUpsertReturns({
+        consecutiveCleanups: 1,
+        lastCleanupTime: cleanupTime,
+        consecutiveDegraded: 0,
+        lastHealthyTime: healthyTime,
+      });
 
-      // Clear cache
-      RecoveryStateService.clearCache();
+      const afterCleanup = await RecoveryStateService.recordCleanup();
+      const afterHealthy = await RecoveryStateService.resetOnHealthy();
 
-      // Next getState should query DB again
-      await RecoveryStateService.getState();
+      expect(afterCleanup.consecutiveCleanups).toBe(1);
+      expect(afterHealthy.consecutiveDegraded).toBe(0);
+      expect(afterHealthy.lastCleanupTime).toEqual(cleanupTime);
+      expect(afterHealthy.lastHealthyTime).toEqual(healthyTime);
 
-      // findUnique should be called twice (once before clear, once after)
-      expect(mockPrisma.recoveryState.findUnique).toHaveBeenCalledTimes(2);
+      expect(mockPrisma.recoveryState.upsert).toHaveBeenCalledTimes(2);
+      expect(mockPrisma.recoveryState.findUnique).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/api/cron/route.ts
+++ b/app/api/cron/route.ts
@@ -904,8 +904,9 @@ async function handleAutoRecover(request: NextRequest) {
     if (cleanupResults.total > 0 || cleanupResults.errors.length > 0) {
       console.log('[AutoRecover] Immediate cleanup completed:', cleanupResults);
       await sendSlackCleanupNotification(cleanupResults);
-      if (cleanupResults.total > 0) await RecoveryStateService.recordCleanup();
-      const updatedState = await RecoveryStateService.getState();
+      const updatedState = cleanupResults.total > 0
+        ? await RecoveryStateService.recordCleanup()
+        : await RecoveryStateService.getState();
       const duration = Date.now() - startTime;
       return NextResponse.json({
         action: cleanupResults.errors.length > 0 ? 'cleanup-with-errors' : 'immediate-cleanup',
@@ -931,8 +932,7 @@ async function handleAutoRecover(request: NextRequest) {
     let result: Record<string, unknown> = {};
 
     if (health.status === 'HEALTHY') {
-      await RecoveryStateService.resetOnHealthy();
-      const healthyState = await RecoveryStateService.getState();
+      const healthyState = await RecoveryStateService.resetOnHealthy();
       return NextResponse.json({
         action: 'none',
         reason: 'Pipeline is healthy',
@@ -954,8 +954,7 @@ async function handleAutoRecover(request: NextRequest) {
       reason = `${health.locks.staleCount} stale locks detected`;
       const cleanupResult = await triggerForceCleanup();
       result = cleanupResult;
-      await RecoveryStateService.recordCleanup();
-      const cleanupState = await RecoveryStateService.getState();
+      const cleanupState = await RecoveryStateService.recordCleanup();
       console.log('[AutoRecover] Lock cleanup triggered:', {
         reason,
         locksCleared: cleanupResult.locksCleared,
@@ -1009,22 +1008,19 @@ async function handleAutoRecover(request: NextRequest) {
       reason = `Pipeline stalled for ${health.minutesSinceLastCompletion} minutes`;
       const redeployResult = await triggerRedeploy(reason);
       result = redeployResult;
-      await RecoveryStateService.recordRedeploy();
-      const redeployState = await RecoveryStateService.getState();
+      const redeployState = await RecoveryStateService.recordRedeploy();
       console.log('[AutoRecover] Redeploy triggered:', {
         reason,
         deploymentId: redeployResult.deploymentId,
         consecutiveRedeploys: redeployState.consecutiveRedeploys,
       });
     } else if (health.status === 'DEGRADED') {
-      await RecoveryStateService.incrementConsecutiveDegraded();
-      const degradedState = await RecoveryStateService.getState();
+      const degradedState = await RecoveryStateService.incrementConsecutiveDegraded();
 
       if (degradedState.consecutiveDegraded >= DEGRADED_ACTION_THRESHOLD) {
         action = 'proactive-investigation';
         reason = `Pipeline degraded for ${degradedState.consecutiveDegraded * 5} minutes`;
-        await RecoveryStateService.resetOnHealthy();
-        const resetState = await RecoveryStateService.getState();
+        const resetState = await RecoveryStateService.resetOnHealthy();
         console.log('[AutoRecover] Proactive investigation triggered:', {
           reason,
           previousConsecutiveDegraded: DEGRADED_ACTION_THRESHOLD,

--- a/lib/cron/recovery-state-service.ts
+++ b/lib/cron/recovery-state-service.ts
@@ -1,17 +1,16 @@
 /**
  * RecoveryStateService - Persistent auto-recovery state management
  *
- * This service manages recovery state that persists in the database,
- * surviving Vercel deployments. Previously, recovery state was stored
- * in-memory and would reset on every deployment, causing:
+ * Persists auto-recovery state across Vercel deployments. Previously,
+ * recovery state was stored in-memory and would reset on every deployment,
+ * causing:
  * - False healthy signals after deploys during ongoing incidents
  * - Reset of consecutiveDegraded counters before action thresholds
  * - Loss of cleanup/redeploy history
  *
- * Key features:
- * - Singleton pattern in database (single row with id='singleton')
- * - In-memory caching for performance (cleared on simulated deploy)
- * - All methods use upsert to handle missing row gracefully
+ * The module is a deep singleton over the `RecoveryState` row (id='singleton').
+ * Every mutation returns the fresh RecoveryState the caller then reads —
+ * callers do not chain `mutate() + getState()`.
  *
  * @see docs/plans/2026-01-09-eliminate-manual-pipeline-intervention.md Phase 1
  */
@@ -31,9 +30,8 @@ export interface RecoveryState {
   lastDegradedTime: Date | null;
 }
 
-/**
- * Default state values for initialization
- */
+const SINGLETON_ID = 'singleton';
+
 const DEFAULT_STATE: RecoveryState = {
   consecutiveDegraded: 0,
   consecutiveCleanups: 0,
@@ -45,34 +43,47 @@ const DEFAULT_STATE: RecoveryState = {
 };
 
 /**
- * In-memory cache for performance.
- * Refreshed from DB on each getState() call.
- * Can be cleared via clearCache() to simulate deploy.
+ * Fields that may appear on a raw `recoveryState` row. Only the persisted
+ * columns are used here; the returned object is coerced to `RecoveryState`
+ * defaults when a column is missing.
  */
-let cachedState: RecoveryState | null = null;
+interface RawRecoveryRow {
+  consecutiveDegraded?: number;
+  consecutiveCleanups?: number;
+  consecutiveRedeploys?: number;
+  lastCleanupTime?: Date | null;
+  lastRedeployTime?: Date | null;
+  lastHealthyTime?: Date | null;
+  lastDegradedTime?: Date | null;
+}
+
+function toState(row: RawRecoveryRow | null | undefined): RecoveryState {
+  if (!row) return { ...DEFAULT_STATE };
+  return {
+    consecutiveDegraded: row.consecutiveDegraded ?? 0,
+    consecutiveCleanups: row.consecutiveCleanups ?? 0,
+    consecutiveRedeploys: row.consecutiveRedeploys ?? 0,
+    lastCleanupTime: row.lastCleanupTime ?? null,
+    lastRedeployTime: row.lastRedeployTime ?? null,
+    lastHealthyTime: row.lastHealthyTime ?? null,
+    lastDegradedTime: row.lastDegradedTime ?? null,
+  };
+}
 
 /**
  * RecoveryStateService provides persistent storage for auto-recovery state.
  *
+ * Every mutation returns the fresh `RecoveryState` after write, so callers
+ * never need `await X.mutate(); const state = await X.getState();`.
+ *
  * Usage:
  * ```typescript
- * // Get current state
  * const state = await RecoveryStateService.getState();
- *
- * // Update on degraded health
- * await RecoveryStateService.incrementConsecutiveDegraded();
- *
- * // Reset when healthy
- * await RecoveryStateService.resetOnHealthy();
- *
- * // Record recovery actions
- * await RecoveryStateService.recordCleanup();
- * await RecoveryStateService.recordRedeploy();
+ * const afterCleanup = await RecoveryStateService.recordCleanup();
+ * const afterHealthy = await RecoveryStateService.resetOnHealthy();
  * ```
  */
 export class RecoveryStateService {
-  private static readonly SINGLETON_ID = 'singleton';
-
   /**
    * Get current recovery state from database.
    * Creates default state if none exists.
@@ -81,42 +92,30 @@ export class RecoveryStateService {
     const prisma = getPrismaClient();
 
     const dbState = await prisma.recoveryState.findUnique({
-      where: { id: this.SINGLETON_ID },
+      where: { id: SINGLETON_ID },
     });
 
     if (!dbState) {
-      // Create default state if doesn't exist
-      await prisma.recoveryState.create({
-        data: { id: this.SINGLETON_ID },
+      const created = await prisma.recoveryState.create({
+        data: { id: SINGLETON_ID },
       });
-      cachedState = { ...DEFAULT_STATE };
-      return cachedState;
+      return toState(created as RawRecoveryRow);
     }
 
-    cachedState = {
-      consecutiveDegraded: dbState.consecutiveDegraded,
-      consecutiveCleanups: dbState.consecutiveCleanups,
-      consecutiveRedeploys: dbState.consecutiveRedeploys,
-      lastCleanupTime: dbState.lastCleanupTime,
-      lastRedeployTime: dbState.lastRedeployTime,
-      lastHealthyTime: dbState.lastHealthyTime,
-      lastDegradedTime: dbState.lastDegradedTime,
-    };
-
-    return cachedState;
+    return toState(dbState as RawRecoveryRow);
   }
 
   /**
-   * Increment consecutive degraded counter and update timestamp.
+   * Increment consecutive-degraded counter and refresh timestamp.
    * Called when pipeline health is DEGRADED.
    */
-  static async incrementConsecutiveDegraded(): Promise<void> {
+  static async incrementConsecutiveDegraded(): Promise<RecoveryState> {
     const prisma = getPrismaClient();
 
-    await prisma.recoveryState.upsert({
-      where: { id: this.SINGLETON_ID },
+    const row = await prisma.recoveryState.upsert({
+      where: { id: SINGLETON_ID },
       create: {
-        id: this.SINGLETON_ID,
+        id: SINGLETON_ID,
         consecutiveDegraded: 1,
         lastDegradedTime: new Date(),
       },
@@ -126,21 +125,20 @@ export class RecoveryStateService {
       },
     });
 
-    // Invalidate cache
-    cachedState = null;
+    return toState(row as RawRecoveryRow);
   }
 
   /**
    * Record a cleanup action.
-   * Increments cleanup counter and updates timestamp.
+   * Increments cleanup counter and refreshes timestamp.
    */
-  static async recordCleanup(): Promise<void> {
+  static async recordCleanup(): Promise<RecoveryState> {
     const prisma = getPrismaClient();
 
-    await prisma.recoveryState.upsert({
-      where: { id: this.SINGLETON_ID },
+    const row = await prisma.recoveryState.upsert({
+      where: { id: SINGLETON_ID },
       create: {
-        id: this.SINGLETON_ID,
+        id: SINGLETON_ID,
         consecutiveCleanups: 1,
         lastCleanupTime: new Date(),
       },
@@ -150,21 +148,20 @@ export class RecoveryStateService {
       },
     });
 
-    // Invalidate cache
-    cachedState = null;
+    return toState(row as RawRecoveryRow);
   }
 
   /**
    * Record a redeploy action.
-   * Increments redeploy counter and updates timestamp.
+   * Increments redeploy counter and refreshes timestamp.
    */
-  static async recordRedeploy(): Promise<void> {
+  static async recordRedeploy(): Promise<RecoveryState> {
     const prisma = getPrismaClient();
 
-    await prisma.recoveryState.upsert({
-      where: { id: this.SINGLETON_ID },
+    const row = await prisma.recoveryState.upsert({
+      where: { id: SINGLETON_ID },
       create: {
-        id: this.SINGLETON_ID,
+        id: SINGLETON_ID,
         consecutiveRedeploys: 1,
         lastRedeployTime: new Date(),
       },
@@ -174,21 +171,20 @@ export class RecoveryStateService {
       },
     });
 
-    // Invalidate cache
-    cachedState = null;
+    return toState(row as RawRecoveryRow);
   }
 
   /**
    * Reset state when pipeline returns to healthy.
    * Resets degraded counter but preserves cleanup/redeploy history.
    */
-  static async resetOnHealthy(): Promise<void> {
+  static async resetOnHealthy(): Promise<RecoveryState> {
     const prisma = getPrismaClient();
 
-    await prisma.recoveryState.upsert({
-      where: { id: this.SINGLETON_ID },
+    const row = await prisma.recoveryState.upsert({
+      where: { id: SINGLETON_ID },
       create: {
-        id: this.SINGLETON_ID,
+        id: SINGLETON_ID,
         consecutiveDegraded: 0,
         lastHealthyTime: new Date(),
       },
@@ -198,20 +194,19 @@ export class RecoveryStateService {
       },
     });
 
-    // Invalidate cache
-    cachedState = null;
+    return toState(row as RawRecoveryRow);
   }
 
   /**
    * Full reset of all state.
    * Used for testing or manual intervention.
    */
-  static async reset(): Promise<void> {
+  static async reset(): Promise<RecoveryState> {
     const prisma = getPrismaClient();
 
-    await prisma.recoveryState.upsert({
-      where: { id: this.SINGLETON_ID },
-      create: { id: this.SINGLETON_ID },
+    const row = await prisma.recoveryState.upsert({
+      where: { id: SINGLETON_ID },
+      create: { id: SINGLETON_ID },
       update: {
         consecutiveDegraded: 0,
         consecutiveCleanups: 0,
@@ -223,14 +218,6 @@ export class RecoveryStateService {
       },
     });
 
-    cachedState = null;
-  }
-
-  /**
-   * Clear in-memory cache.
-   * Used to simulate Vercel deployment in tests.
-   */
-  static clearCache(): void {
-    cachedState = null;
+    return toState(row as RawRecoveryRow);
   }
 }


### PR DESCRIPTION
## Deepening

Replaces the 7-method shallow `RecoveryStateService` interface with a 6-method
deep one whose 5 mutation methods return the fresh `RecoveryState` after
writing. Callers stop chaining `mutate() + getState()`.

**Vocabulary** (per [LANGUAGE.md](../blob/main/LANGUAGE.md)): The interface
shrinks by one entry point (`clearCache`) and every mutation entry point gains
a return payload — the module's **depth** goes up because more behaviour sits
behind the same interface footprint. **Locality** for the maintainer improves:
"how do I read state after a mutation" is now answered by the module, not by
six identical mutate-then-read chains in the caller.

## Leverage callers gain

Before, `app/api/cron/route.ts:handleAutoRecover` repeated this pattern six
times:

```typescript
await RecoveryStateService.recordCleanup();
const updatedState = await RecoveryStateService.getState();
```

After, callers write the equivalent as one line:

```typescript
const updatedState = await RecoveryStateService.recordCleanup();
```

Six chained pairs collapse to six single calls. The auto-recover handler now
carries two standalone `getState()` calls (initial and final) plus one
mutation-and-read per branch — no read-after-mutate ritual.

## Locality maintainers gain

The private in-memory `cachedState` variable and its `clearCache()` escape
hatch are gone. That cache was pure dead performance code: because production
only ever calls `getState()` once per mutation (never twice back-to-back), the
cache was never read across a mutation and its invalidation always happened
before a read that would have hit it. Its only real purpose was to be reset by
a test helper. Deleting it removes 8 LOC of module-level state plus 5
scattered `cachedState = null` invalidations from mutation bodies.

## Dependency category and adapter strategy

Per [Deepening/deepening.md](../blob/main/process/Deepening/deepening.md) §1
this is a **local-substitutable** module (Prisma). No adapter change; the
deepening sits at the module's own interface, not at its dependency seam.
Prisma's `upsert` already returns the mutated row, so the "return fresh state"
change is a zero-round-trip win.

## Tests

- **Added at the deepened interface** (`__tests__/cron/persistent-recovery-state.test.ts`,
  8 cases): every case asserts on the `RecoveryState` returned by a mutation
  — the observable outcome through the interface.
- **Deleted**: the pre-deepening cases that asserted on Prisma `upsert` call
  shape (`expect.objectContaining({ update: { increment: 1 } })`) — past the
  interface. Also deleted: the `clearCache` case, which tested behaviour of a
  cache that no longer exists.
- **Updated**: `__tests__/cron/comprehensive-auto-recover.test.ts` mocks —
  mutations now return the fresh state; `clearCache` and its test-only
  "simulate deploy" line are gone.

The new `mutation-then-caller pattern` case verifies the leverage claim
directly: a caller drives a full cleanup + healthy sequence without any
follow-up `getState()`, and the mock records zero `findUnique` calls.

## ADRs

No ADR conflict. No ADR added. This deepening matches the shape captured in
CONTEXT.md's precedent modules (Onboarding First Email, Template Selection,
Email Link Token) — a shallow multi-method module with a single caller
becomes a deep module whose interface returns everything the caller needs.

## Files

- `lib/cron/recovery-state-service.ts` — mutation methods return
  `Promise<RecoveryState>`; `clearCache()` and module-level `cachedState`
  deleted.
- `app/api/cron/route.ts` — six `mutate() + getState()` pairs collapsed to
  single mutation calls in `handleAutoRecover`.
- `__tests__/cron/persistent-recovery-state.test.ts` — rewritten to assert on
  observable outcomes at the interface.
- `__tests__/cron/comprehensive-auto-recover.test.ts` — mocks updated.



---
_Generated by [Claude Code](https://claude.ai/code/session_01VpHfyhTX3NtzMVmMcaTtyc)_