### PR TITLE
deepen: slim CronAuthService to its used one-method interface

### DIFF
--- a/__tests__/lib/cron/import-path-validation.test.ts
+++ b/__tests__/lib/cron/import-path-validation.test.ts
@@ -128,12 +128,10 @@ describe('Import Path Validation', () => {
       // Verify the modules work in Node.js runtime
       expect(typeof process).toBe('object');
       expect(process.versions.node).toBeDefined();
-      
+
       const { CronAuthService } = await import('../../../lib/cron/auth-service');
-      expect(CronAuthService.detectPlatform).toBeDefined();
-      
-      const platform = CronAuthService.detectPlatform();
-      expect(['RAILWAY_CRON', 'VERCEL_CRON', 'MANUAL_TRIGGER']).toContain(platform);
+      expect(CronAuthService.validateCronRequest).toBeDefined();
+      expect(typeof CronAuthService.validateCronRequest).toBe('function');
     });
 
     test('should handle Edge Runtime environment', async () => {
@@ -188,19 +186,17 @@ describe('Import Path Validation', () => {
     test('should have correct TypeScript types for imports', async () => {
       const { CronAuthService } = await import('../../../lib/cron/auth-service');
       const { rateLimiter } = await import('../../../lib/security/rate-limiter');
-      
+
       // Type checks - these will fail at compile time if types are wrong
       expect(typeof CronAuthService.validateCronRequest).toBe('function');
-      expect(typeof CronAuthService.extractClientIP).toBe('function');
-      expect(typeof CronAuthService.validateEnvironmentConfig).toBe('function');
-      
+
       expect(typeof rateLimiter.checkLimit).toBe('function');
-      
+
       // Test method signatures work correctly
       const mockRequest = { headers: { get: jest.fn() } } as any;
       const authResult = await CronAuthService.validateCronRequest(mockRequest);
       expect(authResult).toHaveProperty('isValid');
-      
+
       const rateLimitResult = await rateLimiter.checkLimit('test', '127.0.0.1');
       expect(rateLimitResult).toHaveProperty('allowed');
     });

--- a/__tests__/pr-validation/pr-changes-validation.test.ts
+++ b/__tests__/pr-validation/pr-changes-validation.test.ts
@@ -82,67 +82,7 @@ describe('PR Changes Validation', () => {
     });
   });
 
-  describe('Runtime Validation', () => {
-    test('should execute auth service static methods without errors', async () => {
-      const { CronAuthService } = await import('../../lib/cron/auth-service');
-      
-      // Test static methods that don't require external dependencies
-      expect(typeof CronAuthService.detectPlatform).toBe('function');
-      expect(typeof CronAuthService.validateEnvironmentConfig).toBe('function');
-      
-      // These should execute without throwing
-      const platform = CronAuthService.detectPlatform();
-      expect(['RAILWAY_CRON', 'VERCEL_CRON', 'MANUAL_TRIGGER']).toContain(platform);
-      
-      const envConfig = CronAuthService.validateEnvironmentConfig();
-      expect(envConfig).toHaveProperty('isValid');
-      expect(envConfig).toHaveProperty('errors');
-      expect(Array.isArray(envConfig.errors)).toBe(true);
-    });
-
-    test('should create mock request and validate extraction methods', async () => {
-      const { CronAuthService } = await import('../../lib/cron/auth-service');
-      
-      const mockRequest = {
-        headers: {
-          get: jest.fn((name: string) => {
-            if (name === 'x-forwarded-for') return '127.0.0.1';
-            if (name === 'x-real-ip') return '192.168.1.1';
-            return null;
-          })
-        },
-        ip: '10.0.0.1'
-      } as any;
-      
-      // Test IP extraction method
-      const clientIP = CronAuthService.extractClientIP(mockRequest);
-      expect(clientIP).toBe('127.0.0.1'); // Should use x-forwarded-for first
-    });
-  });
-
   describe('Quality Assurance Checks', () => {
-    test('should maintain consistent error handling patterns', async () => {
-      // Verify that our changes maintain consistent error handling
-      const { CronAuthService } = await import('../../lib/cron/auth-service');
-      
-      // Test environment validation returns proper structure
-      const config = CronAuthService.validateEnvironmentConfig();
-      expect(typeof config.isValid).toBe('boolean');
-      expect(Array.isArray(config.errors)).toBe(true);
-    });
-
-    test('should not introduce security vulnerabilities', async () => {
-      // Basic security validation
-      const { CronAuthService } = await import('../../lib/cron/auth-service');
-      
-      // Ensure timing-safe comparison method exists
-      expect(CronAuthService.validateEnvironmentConfig).toBeDefined();
-      
-      // The fact that we can import the module means the rate limiter import is working
-      // and the security module is properly accessible
-      expect(true).toBe(true);
-    });
-
     test('should not break existing functionality', () => {
       // Test that existing callers of trackCacheAccess still work
       const mockFunction = jest.fn();

--- a/lib/cron/auth-service.ts
+++ b/lib/cron/auth-service.ts
@@ -1,18 +1,36 @@
 /**
- * Authentication and security service for cron endpoints
- * Enhanced with HMAC-based cryptographic authentication
+ * Authentication service for cron endpoints — behind the one-method
+ * interface production actually calls (validateCronRequest). The former
+ * fanned-out surface (detectPlatform, extractClientIP,
+ * validateEnvironmentConfig, validateCronSecret, isValidIP,
+ * timingSafeEqual) was exported for hypothetical seams that never
+ * shipped: nothing in production reads the platform, extracts the IP
+ * outside of validateCronRequest itself, validates the environment
+ * config at import time, or holds a bearer-token authentication path
+ * (HMAC replaced it). Their tests asserted on those method surfaces
+ * directly — past the interface, not through it.
  */
 
 import { NextRequest } from 'next/server';
 import { logger } from '../logging';
 import { validateCronRequestHmac } from '../security/hmac-auth';
-import type { AuthValidationResult, AuthHeaders } from './types';
+import type { AuthValidationResult } from './types';
 
 const authLogger = logger.child('cron-auth');
 
 export class CronAuthService {
   /**
-   * Validate cron request authentication with HMAC cryptographic verification
+   * Validate cron request authentication with HMAC cryptographic verification.
+   *
+   * Layered gates, short-circuiting in order:
+   *   1. `x-security-validated: true` — middleware.ts already authenticated.
+   *   2. `x-vercel-cron: 1|true` — Vercel internal cron trigger.
+   *   3. HMAC signature (Cloudflare Worker requests).
+   *   4. IP allowlist (`CRON_ALLOWED_IPS`, optional).
+   *   5. Rate limit (`cron-endpoint`).
+   *
+   * Every gate is failsafe-off: any thrown error resolves to
+   * `{ isValid: false, error: 'Authentication validation error' }`.
    */
   static async validateCronRequest(request: NextRequest): Promise<AuthValidationResult> {
     try {
@@ -105,76 +123,15 @@ export class CronAuthService {
     }
   }
 
-  /**
-   * Validate CRON_SECRET with timing-safe comparison
-   */
-  private static validateCronSecret(authHeaders: AuthHeaders): AuthValidationResult {
-    const cronSecret = process.env.CRON_SECRET;
-    
-    if (!cronSecret) {
-      authLogger.error('CRON_SECRET not configured');
-      return {
-        isValid: false,
-        error: 'Authentication not properly configured'
-      };
-    }
-
-    if (cronSecret.length < 32) {
-      authLogger.error('CRON_SECRET not properly configured - insufficient length');
-      return {
-        isValid: false,
-        error: 'Authentication not properly configured'
-      };
-    }
-
-    // Check both Authorization and X-Cron-Auth headers
-    const authHeader = authHeaders.authorization || authHeaders['x-cron-auth'];
-    
-    if (!authHeader) {
-      authLogger.warn('Missing authorization header');
-      return {
-        isValid: false,
-        error: 'Missing Authorization header'
-      };
-    }
-
-    if (!authHeader.startsWith('Bearer ')) {
-      authLogger.warn('Invalid authorization header format');
-      return {
-        isValid: false,
-        error: 'Invalid authorization header format'
-      };
-    }
-
-    const token = authHeader.slice(7); // Remove 'Bearer '
-    
-    // Use timing-safe comparison to prevent timing attacks
-    const isValidToken = this.timingSafeEqual(token, cronSecret);
-    
-    if (!isValidToken) {
-      authLogger.warn('Invalid authorization token');
-      return {
-        isValid: false,
-        error: 'Invalid authorization token'
-      };
-    }
-
-    return { isValid: true };
-  }
-
-  /**
-   * Validate IP allowlist if configured
-   */
   private static validateIPAllowlist(clientIP: string): AuthValidationResult {
     const allowedIPs = process.env.CRON_ALLOWED_IPS;
-    
+
     if (!allowedIPs) {
-      // No IP allowlist configured, allow all IPs
       return { isValid: true };
     }
 
     const allowedIPList = allowedIPs.split(',').map(ip => ip.trim());
-    
+
     if (!allowedIPList.includes(clientIP)) {
       authLogger.warn('IP not in allowlist', { clientIP, allowedIPs: allowedIPList });
       return {
@@ -186,15 +143,11 @@ export class CronAuthService {
     return { isValid: true };
   }
 
-  /**
-   * Validate rate limiting for direct calls
-   */
   private static async validateRateLimit(clientIP: string): Promise<AuthValidationResult> {
     try {
-      // Dynamic import to avoid build-time dependencies
       const { rateLimiter } = await import('../security/rate-limiter');
       const rateLimitResult = await rateLimiter.checkLimit('cron-endpoint', clientIP);
-      
+
       if (!rateLimitResult || !rateLimitResult.allowed) {
         authLogger.warn('Rate limit exceeded', { clientIP, rateLimitResult });
         return {
@@ -209,91 +162,5 @@ export class CronAuthService {
       // Don't fail auth if rate limiter has issues
       return { isValid: true };
     }
-  }
-
-  /**
-   * Timing-safe string comparison to prevent timing attacks
-   */
-  private static timingSafeEqual(a: string, b: string): boolean {
-    const encoder = new TextEncoder();
-    const aBytes = encoder.encode(a);
-    const bBytes = encoder.encode(b);
-    
-    // Compare lengths first
-    let isValid = aBytes.length === bBytes.length;
-    
-    // Always compare full length to prevent timing attacks
-    const maxLength = Math.max(aBytes.length, bBytes.length);
-    for (let i = 0; i < maxLength; i++) {
-      const aByte = i < aBytes.length ? aBytes[i] : 0;
-      const bByte = i < bBytes.length ? bBytes[i] : 0;
-      if (aByte !== bByte) {
-        isValid = false;
-      }
-    }
-    
-    return isValid;
-  }
-
-  /**
-   * Detect platform based on environment variables
-   */
-  static detectPlatform(): 'RAILWAY_CRON' | 'VERCEL_CRON' | 'MANUAL_TRIGGER' {
-    if (process.env.RAILWAY_ENVIRONMENT) {
-      return 'MANUAL_TRIGGER';
-    }
-    return 'VERCEL_CRON';
-  }
-
-  /**
-   * Extract client IP with fallback chain
-   */
-  static extractClientIP(request: NextRequest): string {
-    return (
-      request.headers.get('x-forwarded-for') ||
-      request.headers.get('x-real-ip') ||
-      request.ip ||
-      'unknown'
-    );
-  }
-
-  /**
-   * Validate environment configuration for cron authentication
-   */
-  static validateEnvironmentConfig(): { isValid: boolean; errors: string[] } {
-    const errors: string[] = [];
-    
-    const cronSecret = process.env.CRON_SECRET;
-    if (!cronSecret) {
-      errors.push('CRON_SECRET environment variable not configured');
-    } else if (cronSecret.length < 32) {
-      errors.push('CRON_SECRET must be at least 32 characters long');
-    }
-
-    const allowedIPs = process.env.CRON_ALLOWED_IPS;
-    if (allowedIPs) {
-      const ipList = allowedIPs.split(',').map(ip => ip.trim());
-      const invalidIPs = ipList.filter(ip => !this.isValidIP(ip));
-      if (invalidIPs.length > 0) {
-        errors.push(`Invalid IP addresses in CRON_ALLOWED_IPS: ${invalidIPs.join(', ')}`);
-      }
-    }
-
-    return {
-      isValid: errors.length === 0,
-      errors
-    };
-  }
-
-  /**
-   * Basic IP address validation
-   */
-  private static isValidIP(ip: string): boolean {
-    // Basic IPv4 validation
-    const ipv4Regex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
-    // Basic IPv6 validation (simplified)
-    const ipv6Regex = /^(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$/;
-    
-    return ipv4Regex.test(ip) || ipv6Regex.test(ip) || ip === 'localhost' || ip === '127.0.0.1';
   }
 }

--- a/lib/cron/types.ts
+++ b/lib/cron/types.ts
@@ -123,16 +123,9 @@ export interface AuthValidationResult {
   error?: string;
   clientIP?: string;
   hmacValidated?: boolean;
+  vercelCron?: boolean;
   timestamp?: number;
   skew?: number;
-}
-
-export interface AuthHeaders {
-  authorization?: string;
-  'x-cron-auth'?: string;
-  'x-forwarded-for'?: string;
-  'x-real-ip'?: string;
-  'x-security-validated'?: string;
 }
 
 // ===== CONSTANTS =====


### PR DESCRIPTION
## Deepening

Replaces a 6-method module with one deep **CronAuthService** module behind a **1-method** interface. Only `validateCronRequest` had production callers — ~10 sites across `app/api/cron/route.ts`, `app/api/cron/enrichment-ledger-cleanup/route.ts`, `app/api/cron/weekly-digest/route.ts`, and `app/api/cron/prompt-improvement/route.ts`.

## Interface

**Before**: `validateCronRequest`, `detectPlatform`, `extractClientIP`, `validateEnvironmentConfig`, `validateCronSecret` (private), `timingSafeEqual` (private), `isValidIP` (private) — plus `AuthHeaders` type from `lib/cron/types.ts` exported for `validateCronSecret`.

**After**: `validateCronRequest(request) → Promise<AuthValidationResult>` — the one method production actually exercises. The other five methods were exported for hypothetical seams that never shipped:

- `detectPlatform` — no reader; the returned `'RAILWAY_CRON' | 'VERCEL_CRON' | 'MANUAL_TRIGGER'` branches nothing.
- `extractClientIP` — only `validateCronRequest` itself extracts client IP now (via inline header reads); external callers use `lib/security/middleware-security.ts`'s `IPValidator.extractClientIP`.
- `validateEnvironmentConfig` — no import-time or runtime consumer.
- `validateCronSecret` (private) + `timingSafeEqual` (private) — a parallel bearer-token authentication path that HMAC replaced. No live code path calls it.
- `isValidIP` (private) — only used by the deleted `validateEnvironmentConfig`.

Their tests in `__tests__/pr-validation/pr-changes-validation.test.ts` and `__tests__/lib/cron/import-path-validation.test.ts` asserted on these method surfaces directly — **past the interface, not through it**. Deleted the *Runtime Validation* + *Quality Assurance* sub-suites in `pr-changes-validation` and the `detectPlatform` / `extractClientIP` / `validateEnvironmentConfig` type-check assertions in `import-path-validation`. The 23 remaining assertions in those two files still pass.

The `AuthHeaders` type in `lib/cron/types.ts` was consumed only by `validateCronSecret` and is removed alongside it. Added a `vercelCron?: boolean` field to `AuthValidationResult` (already set by `validateCronRequest` but previously untyped).

## Dependency category

**In-process** for the fast-path gates (`x-security-validated`, `x-vercel-cron`, HMAC, IP allowlist) + **true external** for the rate-limiter dynamic import (per `process/Deepening/deepening.md` §1 and §4). Rate-limiter stays as a private internal seam — `validateCronRequest` owns the composition of HMAC signature verification, IP allowlisting, and rate-limit checking. Nothing in the interface changes for callers.

## Leverage

Callers of `CronAuthService.validateCronRequest` — the ~10 sites across `app/api/cron/**/route.ts` — are unchanged. The interface shrinks from six static methods to one, so a future reader of the module sees only the gate production actually invokes. Follows the same **one adapter means a hypothetical seam** rule that ADR-0002 called out for extraction-for-testability: five hypothetical seams against zero non-test callers.

## Locality

The auth-service concept's public surface now equals the surface production uses. A maintainer investigating "how does cron authentication work" reads one method's step-by-step gate composition (~120 LOC in one place) instead of six methods scattered across the class body.

## Tests

- **Deleted**: two describe blocks + two typeof assertions across two test files (all asserting on removed method surfaces past the interface).
- **Added**: none — `validateCronRequest` continues to be exercised by `__tests__/api/cron/cleanup-dlq.test.ts`, `__tests__/app/api/cron/enrichment-ledger-cleanup/route.test.ts`, and the remaining import-path-validation cases.

Verified:
- `npx jest __tests__/pr-validation/pr-changes-validation.test.ts __tests__/lib/cron/import-path-validation.test.ts` → 23 pass.
- `npx jest __tests__/api/cron/cleanup-dlq.test.ts` → 9 pass.
- `npx jest __tests__/app/api/cron/enrichment-ledger-cleanup` → 5 pass.
- TypeScript baseline error count drops (1826 → 1824).

## ADR alignment

No ADR conflicts. Direct precedent: **ADR-0002** (Inline Analysis-Depth Scoring into Onboarding Delivery) — same "extraction-for-testability with one caller" shape. Same slim-to-used-surface shape as PR #818 (PreferenceService) and PR #767 (PaymentLogger).

## Files

- `lib/cron/auth-service.ts` — 299 → 165 LOC (five methods + `AuthHeaders` import deleted)
- `lib/cron/types.ts` — 137 → 130 LOC (removed unused `AuthHeaders` interface; added `vercelCron?: boolean` to `AuthValidationResult`)
- `__tests__/pr-validation/pr-changes-validation.test.ts` — 195 → 135 LOC (deleted 2 describe blocks that tested past the interface)
- `__tests__/lib/cron/import-path-validation.test.ts` — small edits removing 2 typeof assertions on deleted methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129v1mzHDPPbtAozX5JfPpZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0129v1mzHDPPbtAozX5JfPpZ)_