### PR TITLE
deepen: slim three-tier-limits to its used const surface

### DIFF
--- a/app/api/user/tickers/route.ts
+++ b/app/api/user/tickers/route.ts
@@ -4,7 +4,7 @@ import { getPrismaClient } from '@/lib/db/prisma';
 import { dbRetry } from '@/lib/db/retry-wrapper';
 import { revalidatePath } from 'next/cache';
 import { z } from 'zod';
-import { checkTierLimit, getTierLimitInfo } from '@/lib/subscription/three-tier-limits';
+import { THREE_TIER_LIMITS } from '@/lib/subscription/three-tier-limits';
 import { convertUserPrefsToTickerPrefs, getDefaultTickerPreferences } from '@/lib/user/preference-sync';
 import { UserPreferences } from '@/lib/user/preference-types';
 import { sendQuarterlyEarningsEmail } from '@/lib/email/quarterly-earnings-service';
@@ -275,17 +275,18 @@ export async function POST(request: Request) {
       });
     }
 
-    // 3-tier limit check with MAX unlimited
+    // 3-tier limit check. THREE_TIER_LIMITS values of -1 mean unlimited
+    // (FREE and MAX today); PRO caps at 25. See lib/subscription/three-tier-limits.ts.
     const currentCount = dbUser.tickers.length;
     const tier = dbUser.subscriptionTier as 'FREE' | 'PRO' | 'MAX';
-    
-    if (checkTierLimit(currentCount, tier)) {
-      const limitInfo = getTierLimitInfo(tier);
+    const tickerLimit = THREE_TIER_LIMITS[tier];
+
+    if (tickerLimit !== -1 && currentCount >= tickerLimit) {
       return NextResponse.json({
         error: `You've reached your ${currentCount} ticker limit for the ${tier} tier`,
         limitReached: true,
         currentTier: tier,
-        maxTickers: limitInfo.limit,
+        maxTickers: tickerLimit,
         currentCount,
         upgradeRequired: tier !== 'MAX' // FREE can upgrade to PRO, PRO can upgrade to MAX
       }, { status: 403 });

--- a/lib/subscription/three-tier-limits.ts
+++ b/lib/subscription/three-tier-limits.ts
@@ -1,22 +1,22 @@
-// Simplified 3-tier system with MAX unlimited
+/**
+ * Per-tier ticker allowance for the [Subscription] surface. `-1` sentinels
+ * unlimited (FREE and MAX today; PRO caps at 25). Consumed by the tickers
+ * API route (`app/api/user/tickers/route.ts`) for the ceiling check and by
+ * the dashboard tickers tab (`components/dashboard/sections/dashboard-tickers-tab.tsx`)
+ * plus the onboarding types file (`app/(auth)/onboarding/types.ts`) for
+ * display.
+ *
+ * Previously the module also exported `checkTierLimit(currentCount, tier)`
+ * and `getTierLimitInfo(tier)` — two shallow wrappers whose only production
+ * caller was the tickers API route, invoked in the same expression. The
+ * `checkTierLimit` body was `limit === -1 ? false : currentCount >= limit`
+ * (2 lines behind a 2-arg interface), and `getTierLimitInfo` returned a
+ * 3-field shape whose `limit` was already `THREE_TIER_LIMITS[tier]` on the
+ * caller side. The seam had one adapter and two callers in one expression
+ * — per LANGUAGE.md that is not a seam.
+ */
 export const THREE_TIER_LIMITS = {
   FREE: -1, // unlimited (same as MAX)
   PRO: 25,
   MAX: -1  // -1 = unlimited (no validation needed)
 } as const;
-
-export function checkTierLimit(currentCount: number, tier: 'FREE' | 'PRO' | 'MAX'): boolean {
-  const limit = THREE_TIER_LIMITS[tier];
-  // MAX tier (-1) is unlimited, so never limit
-  if (limit === -1) return false;
-  
-  return currentCount >= limit;
-}
-
-export function getTierLimitInfo(tier: 'FREE' | 'PRO' | 'MAX') {
-  return {
-    limit: THREE_TIER_LIMITS[tier],
-    tier,
-    unlimited: THREE_TIER_LIMITS[tier] === -1
-  };
-}


### PR DESCRIPTION
## Deepening in LANGUAGE.md vocabulary

Deletes the two shallow function exports (`checkTierLimit` and `getTierLimitInfo`) on `lib/subscription/three-tier-limits.ts` and inlines the tier ceiling check at the sole production call site, `app/api/user/tickers/route.ts`. The `THREE_TIER_LIMITS` const stays put — it has 3 real readers (the API route, the dashboard tickers tab, the onboarding types file) and earns its keep.

Replaces one shallow **module** surface (a 21-LOC file exporting a const plus two pure-function wrappers over that const) with the const alone. The two functions were nearly interface-shaped nothing:

- `checkTierLimit(currentCount, tier)`: body is `limit === -1 ? false : currentCount >= limit` — 2 lines of behaviour behind a 2-argument **interface**.
- `getTierLimitInfo(tier)`: returns a 3-field object where `limit` is `THREE_TIER_LIMITS[tier]` — the caller already has `THREE_TIER_LIMITS` in scope through the same import.

The functions had one production caller, invoked in one expression. Per LANGUAGE.md, "one adapter means a hypothetical seam. Two adapters means a real one." One adapter × one expression is not a seam either — it is indirection.

## Leverage callers gain

The one caller (`app/api/user/tickers/route.ts:282`) now reads its own `currentCount >= tickerLimit` inline instead of hopping to a sibling **module** to learn that a call named `checkTierLimit` means "greater than or equal to the limit unless it's -1 for unlimited." The tier ceiling check is 2 lines of expression at its call site, right next to the 403 response that consumes the answer.

## Locality maintainers gain

The [Subscription] tier-limit concept concentrates in one file (`three-tier-limits.ts`) around one exported **interface** (the const table). A maintainer changing PRO's ceiling — or adding a new tier — edits `THREE_TIER_LIMITS` and every reader picks up the change. The former two-function surface invited future callers to wire up to predicates that had exactly one caller today; removing them means no one will accidentally build a second call site around a helper that was never load-bearing.

## Dependency category (per process/Deepening/deepening.md)

**In-process.** Pure computation on a compile-time const table. No I/O, no adapter, no port.

## Adapter strategy

No adapter change. The const stays; the shallow function wrappers over the const go away.

## Tests deleted and tests added at the new interface

- **Deleted:** none. The deleted functions had no dedicated test file — their behaviour was so trivial that no one felt compelled to test it in isolation, which is itself a signal that the extraction earned no leverage. The seam had zero test **adapters** on top of one call-site adapter.
- **Added:** none. The inline check at `app/api/user/tickers/route.ts:281` now IS the observable behaviour; any test at that route (present or future) exercises it through the route's HTTP interface.

## CONTEXT.md

No entry references `three-tier-limits.ts` or these two functions. The [Subscription] entry does not name specific helpers, so no update required. The [Lifetime Seat] entry (ADR-0004) is separate — MAX users are unlimited via the `-1` sentinel, which the inlined check honours.

## ADRs

- Respects ADR-0001..ADR-0006. ADR-0004 (Lifetime Seat) uses the MAX tier for entitlement; the inlined check still returns unlimited for MAX because the `-1` sentinel is preserved.
- No new ADR — deleting shallow-wrapper functions with one caller each in one expression is not a load-bearing decision.
- Follows the shape of PR #818 (`PreferenceService` slim) and PR #907 (`CronAuthService` slim).

## Verification

- Touched-suite tests: `__tests__/api/user/tickers-integration.test.ts` — 3/3 pass. This test asserts the route module imports cleanly, which catches the class of regression a broken inline-check would cause.
- Full CI-scoped `npm test` with the PR-validation ignore pattern: **231 test suites pass, 3094 tests pass, 28 skipped, 6 todo.** The one failing suite (`supabase-cutover.test.ts`) reproduces on `main` (`c2054c5`) and is unrelated to this change.
- Diff: 2 files, +24 / −23 (net +1 LOC on production; −13 LOC of dead interface behind the const).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPdxodqHENq9RsnUcFAE9k)_